### PR TITLE
feat(packages): add p7zip to basic packages

### DIFF
--- a/playbooks/imports/play-basic-configs.yml
+++ b/playbooks/imports/play-basic-configs.yml
@@ -78,6 +78,7 @@
           - python3-libdnf5
           - multitail
           - figlet
+          - p7zip
       tags: packages
 
     - name: Passwordless Sudo


### PR DESCRIPTION
## Summary

Adds `p7zip` to the basic packages list in `play-basic-configs.yml`, providing the `7za` command for archive handling.

Replaces #14 (which had a stale hooks-daemon install commit that conflicted with F43).

## Test plan

- [ ] Run `./playbooks/imports/play-basic-configs.yml --tags packages` on host
- [ ] Verify `7za` command is available after playbook run

🤖 Generated with [Claude Code](https://claude.com/claude-code)