### PR TITLE
fix(ccy): unblock rootless podman build after host upgrade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,29 @@ Writing code that silently swallows errors is blocked. All errors must be handle
 
 **Required action**: Handle errors explicitly — log them, return them to the caller, or propagate them. Silent error suppression masks bugs and makes debugging impossible.
 
+## gh_issue_comments — always include --comments on gh issue view
+
+`gh issue view` without `--comments` is blocked. Issue comments often contain critical context, clarifications, and updates not in the issue body.
+
+**Blocked**: `gh issue view 123`, `gh issue view 123 --repo owner/repo`
+
+**Allowed**: `gh issue view 123 --comments`, `gh issue view 123 --json title,body,comments`
+
+If using `--json`, include `comments` in the field list instead of adding `--comments`.
+
+## lock_file_edit_blocker — never directly edit lock files
+
+Direct `Write` or `Edit` to package manager lock files is blocked. Lock files are generated artifacts; manual edits create checksum mismatches and broken dependency graphs.
+
+**Blocked files**: `composer.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Gemfile.lock`, `Cargo.lock`, `go.sum`, `Package.resolved`, `Pipfile.lock`, and others.
+
+**Use package manager commands instead**:
+- PHP: `composer install` / `composer require package`
+- Node: `npm install` / `yarn add package`
+- Ruby: `bundle install` / `bundle add gem`
+- Rust: `cargo add crate`
+- Go: `go get module`
+
 ## lsp_enforcement — use LSP tools for code symbol lookups
 
 Using `Grep` or `Bash` (grep/rg) to find class definitions, function signatures, or symbol references is blocked or redirected to LSP tools, which are faster and semantically accurate.
@@ -246,6 +269,50 @@ Using `Grep` or `Bash` (grep/rg) to find class definitions, function signatures,
 **Grep/Bash grep is still appropriate for**: text patterns in content, log searching, finding strings in config files.
 
 Default mode (`block_once`): the first symbol-lookup grep in a session is denied with guidance; subsequent retries are allowed.
+
+## npm_command — use llm: prefixed npm commands
+
+Direct `npm run` and `npx` commands are blocked or advised against. Projects with `llm:` prefixed scripts in `package.json` should use those instead.
+
+**Why**: `llm:` commands are configured for LLM-friendly output (no spinners, no colour codes, structured results).
+
+**Example**: Use `npm run llm:build` instead of `npm run build`.
+
+If no `llm:` commands exist in `package.json`, the handler operates in advisory mode (warns but does not block).
+
+### Pipe Blocker
+
+Commands piped to `tail` or `head` are **blocked** — piping truncates output and causes information loss.
+
+**Use a temp file instead:**
+
+```bash
+# WRONG — blocked:
+pytest tests/ 2>&1 | tail -20
+
+# RIGHT — redirect to temp file:
+pytest tests/ > /tmp/pytest_out.txt 2>&1
+# Then read selectively if needed
+```
+
+**Allowed** (whitelisted): `grep`, `rg`, `awk`, `sed`, `jq`, `ls`, `cat`, `git log`, `git tag`, `git branch`, and other cheap filtering commands.
+
+**Add to whitelist** (if safe to pipe): set `extra_whitelist` in `.claude/hooks-daemon.yaml` under `pipe_blocker`.
+
+## qa_suppression — QA suppression annotations are blocked
+
+Writing QA suppression directives into source files is blocked across all supported languages. Fix the underlying code issue instead.
+
+**Blocked annotation types (by language)**:
+- Python: `noqa` directives, `type: ignore` annotations
+- JavaScript/TypeScript: `eslint-disable` inline directives
+- Go: `nolint` directives (golangci-lint)
+- PHP: `phpstan-ignore`, `psalm-suppress` annotations
+- Java/Kotlin: `@SuppressWarnings`, `@Suppress` annotations
+- C#: `pragma warning disable` directives
+- Rust: `allow(clippy::...)` attributes on type-level items
+
+**Required action**: Fix the code so QA passes without suppression. If a suppression is genuinely necessary, ask the user to add it manually — this signals a conscious decision rather than a shortcut.
 
 ## security_antipattern — OWASP security antipatterns are blocked
 
@@ -320,72 +387,29 @@ Worktrees are isolated branches. Cross-copying corrupts that isolation and can s
 
 **Allowed**: operations within the same worktree branch. **To merge changes**: use `git merge` or `git cherry-pick` instead.
 
-## gh_issue_comments — always include --comments on gh issue view
+## daemon_location_guard — do not cd into .claude/hooks-daemon/
 
-`gh issue view` without `--comments` is blocked. Issue comments often contain critical context, clarifications, and updates not in the issue body.
+Bash commands that change directory into `.claude/hooks-daemon/` (or `cd` into a daemon-internal subdirectory and then run something) are blocked. The daemon is an upstream dependency that must remain untouched in client repos.
 
-**Blocked**: `gh issue view 123`, `gh issue view 123 --repo owner/repo`
+**Run daemon CLI from the project root instead** — it always works regardless of cwd:
 
-**Allowed**: `gh issue view 123 --comments`, `gh issue view 123 --json title,body,comments`
-
-If using `--json`, include `comments` in the field list instead of adding `--comments`.
-
-## lock_file_edit_blocker — never directly edit lock files
-
-Direct `Write` or `Edit` to package manager lock files is blocked. Lock files are generated artifacts; manual edits create checksum mismatches and broken dependency graphs.
-
-**Blocked files**: `composer.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Gemfile.lock`, `Cargo.lock`, `go.sum`, `Package.resolved`, `Pipfile.lock`, and others.
-
-**Use package manager commands instead**:
-- PHP: `composer install` / `composer require package`
-- Node: `npm install` / `yarn add package`
-- Ruby: `bundle install` / `bundle add gem`
-- Rust: `cargo add crate`
-- Go: `go get module`
-
-## npm_command — use llm: prefixed npm commands
-
-Direct `npm run` and `npx` commands are blocked or advised against. Projects with `llm:` prefixed scripts in `package.json` should use those instead.
-
-**Why**: `llm:` commands are configured for LLM-friendly output (no spinners, no colour codes, structured results).
-
-**Example**: Use `npm run llm:build` instead of `npm run build`.
-
-If no `llm:` commands exist in `package.json`, the handler operates in advisory mode (warns but does not block).
-
-### Pipe Blocker
-
-Commands piped to `tail` or `head` are **blocked** — piping truncates output and causes information loss.
-
-**Use a temp file instead:**
-
-```bash
-# WRONG — blocked:
-pytest tests/ 2>&1 | tail -20
-
-# RIGHT — redirect to temp file:
-pytest tests/ > /tmp/pytest_out.txt 2>&1
-# Then read selectively if needed
+```
+$PYTHON -m claude_code_hooks_daemon.daemon.cli status
+$PYTHON -m claude_code_hooks_daemon.daemon.cli restart
+$PYTHON -m claude_code_hooks_daemon.daemon.cli logs
 ```
 
-**Allowed** (whitelisted): `grep`, `rg`, `awk`, `sed`, `jq`, `ls`, `cat`, `git log`, `git tag`, `git branch`, and other cheap filtering commands.
+If you need to inspect daemon source for debugging, use `Read` from the project root with the absolute path — never `cd` in. Do NOT edit anything inside `.claude/hooks-daemon/`; changes will be overwritten on the next upgrade.
 
-**Add to whitelist** (if safe to pipe): set `extra_whitelist` in `.claude/hooks-daemon.yaml` under `pipe_blocker`.
+## gh_pr_comments — always include --comments on gh pr view
 
-## qa_suppression — QA suppression annotations are blocked
+`gh pr view` without `--comments` is blocked. PR comments often contain review feedback, reviewer requests, and decisions not in the PR body.
 
-Writing QA suppression directives into source files is blocked across all supported languages. Fix the underlying code issue instead.
+**Blocked**: `gh pr view 123`, `gh pr view 123 --repo owner/repo`
 
-**Blocked annotation types (by language)**:
-- Python: `noqa` directives, `type: ignore` annotations
-- JavaScript/TypeScript: `eslint-disable` inline directives
-- Go: `nolint` directives (golangci-lint)
-- PHP: `phpstan-ignore`, `psalm-suppress` annotations
-- Java/Kotlin: `@SuppressWarnings`, `@Suppress` annotations
-- C#: `pragma warning disable` directives
-- Rust: `allow(clippy::...)` attributes on type-level items
+**Allowed**: `gh pr view 123 --comments`, `gh pr view 123 --json title,body,comments`
 
-**Required action**: Fix the code so QA passes without suppression. If a suppression is genuinely necessary, ask the user to add it manually — this signals a conscious decision rather than a shortcut.
+If using `--json`, include `comments` in the field list instead of adding `--comments`.
 
 ## git_stash — git stash is blocked by default
 
@@ -400,29 +424,19 @@ MUST_STASH_BECAUSE="explain why"; git stash
 
 Configure via `handlers.pre_tool_use.git_stash.options.mode: warn` for advisory-only mode.
 
-## gh_pr_comments — always include --comments on gh pr view
+## markdown_organization — markdown files must go in allowed locations
 
-`gh pr view` without `--comments` is blocked. PR comments often contain review feedback, reviewer requests, and decisions not in the PR body.
+Writing a new `.md` file to an unrecognised location is blocked. Markdown files must be placed in project-configured allowed paths.
 
-**Blocked**: `gh pr view 123`, `gh pr view 123 --repo owner/repo`
+**Common allowed locations**: `CLAUDE/`, `docs/`, `RELEASES/`, `CLAUDE/Plan/`, root-level `README.md`, or any path matching the `allowed_markdown_paths` config.
 
-**Allowed**: `gh pr view 123 --comments`, `gh pr view 123 --json title,body,comments`
+**Dependency directories**: `vendor/` (PHP) and `node_modules/` (JS) are treated as implicit monorepos — each package is a sub-project where normal markdown rules apply (e.g. `vendor/acme/lib/docs/guide.md` is allowed, `vendor/acme/lib/random/notes.md` is blocked).
 
-If using `--json`, include `comments` in the field list instead of adding `--comments`.
+**Plan file redirection**: when `track_plans_in_project` is enabled, Claude Code planning mode writes are automatically redirected to the project's `CLAUDE/Plan/` directory. Plan folders must follow the `NNNN-description/` naming convention.
 
-## daemon_location_guard — do not cd into .claude/hooks-daemon/
+If you need a markdown file in a new location, add a pattern to `allowed_markdown_paths` in `.claude/hooks-daemon.yaml`.
 
-Bash commands that change directory into `.claude/hooks-daemon/` (or `cd` into a daemon-internal subdirectory and then run something) are blocked. The daemon is an upstream dependency that must remain untouched in client repos.
-
-**Run daemon CLI from the project root instead** — it always works regardless of cwd:
-
-```
-$PYTHON -m claude_code_hooks_daemon.daemon.cli status
-$PYTHON -m claude_code_hooks_daemon.daemon.cli restart
-$PYTHON -m claude_code_hooks_daemon.daemon.cli logs
-```
-
-If you need to inspect daemon source for debugging, use `Read` from the project root with the absolute path — never `cd` in. Do NOT edit anything inside `.claude/hooks-daemon/`; changes will be overwritten on the next upgrade.
+If your project has sub-projects with their own `docs/`, `CLAUDE/`, etc., configure `monorepo_subproject_patterns` in `.claude/hooks-daemon.yaml` so normal rules apply within each sub-project.
 
 ## pip_break_system — --break-system-packages is blocked
 
@@ -451,39 +465,6 @@ pip install --user <package>
 ```
 
 Even in a container running as root, `sudo` adds nothing — drop it and use a venv.
-
-## markdown_organization — markdown files must go in allowed locations
-
-Writing a new `.md` file to an unrecognised location is blocked. Markdown files must be placed in project-configured allowed paths.
-
-**Common allowed locations**: `CLAUDE/`, `docs/`, `RELEASES/`, `CLAUDE/Plan/`, root-level `README.md`, or any path matching the `allowed_markdown_paths` config.
-
-**Dependency directories**: `vendor/` (PHP) and `node_modules/` (JS) are treated as implicit monorepos — each package is a sub-project where normal markdown rules apply (e.g. `vendor/acme/lib/docs/guide.md` is allowed, `vendor/acme/lib/random/notes.md` is blocked).
-
-**Plan file redirection**: when `track_plans_in_project` is enabled, Claude Code planning mode writes are automatically redirected to the project's `CLAUDE/Plan/` directory. Plan folders must follow the `NNNN-description/` naming convention.
-
-If you need a markdown file in a new location, add a pattern to `allowed_markdown_paths` in `.claude/hooks-daemon.yaml`.
-
-If your project has sub-projects with their own `docs/`, `CLAUDE/`, etc., configure `monorepo_subproject_patterns` in `.claude/hooks-daemon.yaml` so normal rules apply within each sub-project.
-
-## ask_user_question_blocker — questions need `ASKING BECAUSE:` justification
-
-AskUserQuestion calls are only allowed when every `question` string begins with `ASKING BECAUSE:` (case-sensitive, leading whitespace OK). The convention mirrors the Stop handler's `STOPPING BECAUSE:` pattern — explicit declared intent gates the privilege of pausing the session.
-
-**Before asking, evaluate critically**:
-- Tautological/rhetorical questions with one obvious answer ("Should I continue?", "Would you like me to proceed?") — do NOT ask. State the question and your assumed-correct answer in plain output text and proceed. The user is watching and will interrupt if the assumption is wrong.
-- Questions whose options reduce to **good vs. bad** are tautological — the answer is always the good option. Examples: best practice vs. bodge, increasing vs. decreasing code quality, delivering the requirement vs. not delivering it, fixing the failing test vs. leaving it broken, following project conventions vs. inventing your own. Do NOT ask; pick the good option and proceed.
-- Errors with a clear recovery path ("Should I fix the failing test?") — do NOT ask. Fix it.
-- Genuine choice questions where you cannot resolve the answer from context — these are the legitimate use case. Prefix every question text with `ASKING BECAUSE: <one-line reason you cannot decide>` so the daemon allows the call through.
-
-**Audit log pattern** (preferred for tautological questions):
-```
-I would normally ask: <question>.
-Assumed answer: <your assumption>.
-Proceeding on that basis; the user will interrupt if wrong.
-```
-
-**Escape hatch** (genuine ambiguity): prefix every question text with `ASKING BECAUSE: <reason>`. Mixing prefixed and non-prefixed questions in one call still triggers a block — prefix all or none.
 
 ## system_paths — do not edit deployed system files directly
 
@@ -541,26 +522,6 @@ On every new session this handler audits hook configuration across `.claude/sett
 - **Missing hooks**: the daemon's installer writes the full set. If any are missing, re-run `install.py` or manually add the missing `{event_name}` entry pointing at `"$CLAUDE_PROJECT_DIR"/.claude/hooks/{bash-key}`.
 - **Duplicate hooks**: a hook registered in both files fires twice. Keep the `settings.json` entry, delete from `settings.local.json`.
 
-## auto_approve_reads — gated on bypassPermissions mode
-
-Read-only tool permission requests (`Read`, `Glob`, `Grep`) are auto-approved **only** when Claude Code reports `permission_mode == "bypassPermissions"` (YOLO mode).
-
-In every other mode (`default`, `plan`, `acceptEdits`, `dontAsk`) the handler defers and Claude Code's normal approval prompt is shown — the user has not opted out of per-tool approvals, so the daemon must not silently approve on their behalf.
-
-If a permission prompt for `Read` appears in `default` mode, that is correct behaviour — approve it via Claude Code's UI.
-
-## dismissive_language_detector — do not deflect or prematurely halt
-
-Stop-time advisory that fires on language patterns signalling avoidance of work. The handler does NOT block the stop, but injects context for the next turn so the agent self-corrects.
-
-**Avoid**:
-
-- Dismissing issues as `pre-existing`, `out of scope`, `not our problem`,   or `not relevant` to deflect work that is in fact yours.
-- Premature-halt phrasing like `natural checkpoint`, `ready to continue on your   cue`, `pausing here` mid-plan when there is more to do — finish the task   rather than dressing up a halt.
-- Speculative `should be fine` or `probably works` when verification is   cheap (run the test, read the file).
-
-**Do**: acknowledge the issue, fix it, or — if it genuinely is out of scope — say so once with the specific reason and continue with the in-scope work.
-
 ### Stop Explanation Required
 
 Before stopping, **prefix your final message** with `STOPPING BECAUSE:` followed by a clear reason:
@@ -585,15 +546,16 @@ STOPPING BECAUSE: all tasks complete, QA passes, daemon restart verified.
 - Errors with a clear next step ("The test failed, should I fix it?") — do NOT ask, just fix it
 - Genuine choice questions where all options are valid ("Which of A, B, or C should we use?") — these deserve a response. Use `STOPPING BECAUSE: need user input` and ask your question
 
-**Recovering from a `tool_use_error` — do NOT stop silently**:
+## dismissive_language_detector — do not deflect or prematurely halt
 
-Some tool errors require an explicit recovery action, not a halt. The most common shape:
-- You call `Edit` or `Write` on a file you have not yet read.
-- Claude Code returns a `tool_use_error` (e.g. "File has not been read yet").
-- The correct recovery is **Read the file, then retry Edit/Write** — **do not stop**. Stopping silently after a tool error triggers a Stop-hook re-entry loop and wastes a turn.
+Stop-time advisory that fires on language patterns signalling avoidance of work. The handler does NOT block the stop, but injects context for the next turn so the agent self-corrects.
 
-**Rule: Read before Edit/Write.** If you must edit a file you have not read, Read it first in the same turn. The daemon's Stop handler will detect a `tool_use_error` followed by a silent stop and re-fire to force recovery.
+**Avoid**:
 
-**On Stop hook re-entry (the hook fires again after a prior block)**: your next response is treated like any other — it must either prefix with `STOPPING BECAUSE:` or continue the work. Re-entry does not exempt you from the explanation rule.
+- Dismissing issues as `pre-existing`, `out of scope`, `not our problem`,   or `not relevant` to deflect work that is in fact yours.
+- Premature-halt phrasing like `natural checkpoint`, `ready to continue on your   cue`, `pausing here` mid-plan when there is more to do — finish the task   rather than dressing up a halt.
+- Speculative `should be fine` or `probably works` when verification is   cheap (run the test, read the file).
+
+**Do**: acknowledge the issue, fix it, or — if it genuinely is out of scope — say so once with the specific reason and continue with the in-scope work.
 
 </hooksdaemon>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,6 @@ Piping network content directly to a shell is blocked. It executes untrusted rem
 **Blocked**: `curl URL | bash`, `curl URL | sh`, `wget URL | bash`, `curl URL | sudo bash`
 
 **Safe alternative**: download first, inspect, then execute:
-
 ```
 curl -o /tmp/script.sh URL
 cat /tmp/script.sh          # inspect
@@ -211,7 +210,6 @@ Before making a `git commit` in the hooks daemon repository, this handler advise
 **Blocked**: `chmod 777`, `chmod 666`, `chmod a+w`, `chmod o+w`
 
 **Use least-privilege permissions instead**:
-
 - Executable scripts: `chmod 755` (owner rwx, group/other rx)
 - Regular files: `chmod 644` (owner rw, group/other r)
 - Private files: `chmod 600` (owner rw only)
@@ -220,17 +218,17 @@ Before making a `git commit` in the hooks daemon repository, this handler advise
 
 The following git commands are permanently blocked and will always be denied:
 
-| Command                  | Reason                                                                   |
-| ------------------------ | ------------------------------------------------------------------------ |
-| `git reset --hard`       | Permanently destroys all uncommitted changes                             |
-| `git clean -f`           | Permanently deletes untracked files                                      |
-| `git checkout -- <file>` | Discards all local changes to that file                                  |
-| `git restore <file>`     | Discards local changes (`--staged` is allowed)                           |
-| `git stash drop`         | Permanently destroys stashed changes                                     |
-| `git stash clear`        | Permanently destroys all stashes                                         |
-| `git push --force`       | Can overwrite remote history and destroy teammates' work                 |
-| `git branch -D`          | Force-deletes branch without checking if merged (lowercase `-d` is safe) |
-| `git commit --amend`     | Rewrites the previous commit — create a new commit instead               |
+| Command | Reason |
+|---------|--------|
+| `git reset --hard` | Permanently destroys all uncommitted changes |
+| `git clean -f` | Permanently deletes untracked files |
+| `git checkout -- <file>` | Discards all local changes to that file |
+| `git restore <file>` | Discards local changes (`--staged` is allowed) |
+| `git stash drop` | Permanently destroys stashed changes |
+| `git stash clear` | Permanently destroys all stashes |
+| `git push --force` | Can overwrite remote history and destroy teammates' work |
+| `git branch -D` | Force-deletes branch without checking if merged (lowercase `-d` is safe) |
+| `git commit --amend` | Rewrites the previous commit — create a new commit instead |
 
 If the user needs to run one of these, ask them to do it manually. Do not attempt to work around the block.
 
@@ -241,7 +239,6 @@ If the user needs to run one of these, ask them to do it manually. Do not attemp
 Writing code that silently swallows errors is blocked. All errors must be handled explicitly.
 
 **Blocked patterns (examples)**:
-
 - Python: bare `except` clauses with an empty body, catching and discarding all exceptions
 - Shell: redirecting stderr to `/dev/null` to silence failures, `|| true` to suppress non-zero exit codes
 - JavaScript/TypeScript: empty `catch` blocks that swallow exceptions
@@ -266,7 +263,6 @@ Direct `Write` or `Edit` to package manager lock files is blocked. Lock files ar
 **Blocked files**: `composer.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Gemfile.lock`, `Cargo.lock`, `go.sum`, `Package.resolved`, `Pipfile.lock`, and others.
 
 **Use package manager commands instead**:
-
 - PHP: `composer install` / `composer require package`
 - Node: `npm install` / `yarn add package`
 - Ruby: `bundle install` / `bundle add gem`
@@ -278,7 +274,6 @@ Direct `Write` or `Edit` to package manager lock files is blocked. Lock files ar
 Using `Grep` or `Bash` (grep/rg) to find class definitions, function signatures, or symbol references is blocked or redirected to LSP tools, which are faster and semantically accurate.
 
 **Prefer LSP tools for**:
-
 - Finding where a class or function is defined → `goToDefinition`
 - Finding all usages of a symbol → `findReferences`
 - Getting type information or documentation → `hover`
@@ -323,7 +318,6 @@ pytest tests/ > /tmp/pytest_out.txt 2>&1
 Writing QA suppression directives into source files is blocked across all supported languages. Fix the underlying code issue instead.
 
 **Blocked annotation types (by language)**:
-
 - Python: `noqa` directives, `type: ignore` annotations
 - JavaScript/TypeScript: `eslint-disable` inline directives
 - Go: `nolint` directives (golangci-lint)
@@ -339,7 +333,6 @@ Writing QA suppression directives into source files is blocked across all suppor
 Writing code that contains security antipatterns is blocked across all supported languages. Fix the code to use safe patterns instead.
 
 **Blocked categories**:
-
 - SQL injection: building queries via string concatenation (use parameterised queries)
 - Command injection: passing unvalidated input to subprocess (use argument lists)
 - Hardcoded credentials: API keys, passwords, tokens embedded in source code
@@ -353,18 +346,15 @@ Writing code that contains security antipatterns is blocked across all supported
 `sed` is blocked because Claude gets sed syntax wrong and a single error can silently destroy hundreds of files with no recovery possible.
 
 **Blocked**:
-
 - `sed -i` / `sed -e` (in-place file editing via Bash tool)
 - `grep -rl X | xargs sed -i` (mass file modification)
 - Shell scripts (`.sh`/`.bash`) written via Write tool that contain `sed`
 
 **Allowed** (read-only, no file modification):
-
 - `cat file | sed 's/x/y/' | grep z` (pipeline transforming stdout only)
 - `sed` mentioned in commit messages, PR bodies, or `.md` documentation files
 
 **Use instead**:
-
 - `Edit` tool — safe, atomic, verifiable
 - Parallel Haiku agents with `Edit` tool for bulk changes across many files:
   1. Identify all files to update
@@ -376,7 +366,6 @@ Writing code that contains security antipatterns is blocked across all supported
 Creating a production source file is blocked until a corresponding test file exists.
 
 **TDD workflow (required)**:
-
 1. Create the **test file first** (e.g. `tests/unit/handlers/test_my_handler.py`)
 2. Write failing tests — RED phase
 3. Create the source file and implement until tests pass — GREEN phase
@@ -385,7 +374,6 @@ Creating a production source file is blocked until a corresponding test file exi
 **Supported languages**: Python, Go, JavaScript/TypeScript, PHP, Rust, Java, C#, Kotlin, Ruby, Swift, Dart
 
 **Test file locations checked** (any satisfies the block):
-
 - Separate mirror: `tests/unit/{subdir}/test_{module}.py`
 - Collocated: `{source_dir}/{module}.test.ts` (JS/TS projects)
 - Test subdirectory: `{source_dir}/__tests__/{module}.test.ts`
@@ -397,7 +385,6 @@ Creating a production source file is blocked until a corresponding test file exi
 Writing ephemeral or session-specific content to `CLAUDE.md` or `README.md` is blocked. These files should contain only stable instructions, not implementation logs or session state.
 
 **Blocked content types**:
-
 - Timestamps and ISO dates
 - Status emoji followed by completion words (e.g. checkmark + 'Done')
 - Implementation log sentences ('created the file X', 'added the class Y')
@@ -445,7 +432,6 @@ If using `--json`, include `comments` in the field list instead of adding `--com
 **Why**: stashes get forgotten, lost, and block `git pull`. Use `git commit -m 'WIP: ...'` instead — WIP commits are acceptable.
 
 **Escape hatch** (when commit truly won't work):
-
 ```
 MUST_STASH_BECAUSE="explain why"; git stash
 ```
@@ -485,14 +471,12 @@ Even in a container running as root, `sudo` adds nothing — drop it and use a v
 AskUserQuestion calls are only allowed when every `question` string begins with `ASKING BECAUSE:` (case-sensitive, leading whitespace OK). The convention mirrors the Stop handler's `STOPPING BECAUSE:` pattern — explicit declared intent gates the privilege of pausing the session.
 
 **Before asking, evaluate critically**:
-
 - Tautological/rhetorical questions with one obvious answer ("Should I continue?", "Would you like me to proceed?") — do NOT ask. State the question and your assumed-correct answer in plain output text and proceed. The user is watching and will interrupt if the assumption is wrong.
 - Questions whose options reduce to **good vs. bad** are tautological — the answer is always the good option. Examples: best practice vs. bodge, increasing vs. decreasing code quality, delivering the requirement vs. not delivering it, fixing the failing test vs. leaving it broken, following project conventions vs. inventing your own. Do NOT ask; pick the good option and proceed.
 - Errors with a clear recovery path ("Should I fix the failing test?") — do NOT ask. Fix it.
 - Genuine choice questions where you cannot resolve the answer from context — these are the legitimate use case. Prefix every question text with `ASKING BECAUSE: <one-line reason you cannot decide>` so the daemon allows the call through.
 
 **Audit log pattern** (preferred for tautological questions):
-
 ```
 I would normally ask: <question>.
 Assumed answer: <your assumption>.
@@ -550,7 +534,6 @@ Writing or editing files under system paths (/etc/, /var/, /usr/, /opt/, /root/,
 These are deployed files managed by Ansible.
 
 **Edit the project source instead**:
-
 - `/etc/foo` → `files/etc/foo`
 - `/var/local/foo` → `files/var/local/foo`
 - `/usr/bin/foo` → `files/usr/bin/foo`
@@ -615,9 +598,9 @@ Stop-time advisory that fires on language patterns signalling avoidance of work.
 
 **Avoid**:
 
-- Dismissing issues as `pre-existing`, `out of scope`, `not our problem`, or `not relevant` to deflect work that is in fact yours.
-- Premature-halt phrasing like `natural checkpoint`, `ready to continue on your   cue`, `pausing here` mid-plan when there is more to do — finish the task rather than dressing up a halt.
-- Speculative `should be fine` or `probably works` when verification is cheap (run the test, read the file).
+- Dismissing issues as `pre-existing`, `out of scope`, `not our problem`,   or `not relevant` to deflect work that is in fact yours.
+- Premature-halt phrasing like `natural checkpoint`, `ready to continue on your   cue`, `pausing here` mid-plan when there is more to do — finish the task   rather than dressing up a halt.
+- Speculative `should be fine` or `probably works` when verification is   cheap (run the test, read the file).
 
 **Do**: acknowledge the issue, fix it, or — if it genuinely is out of scope — say so once with the specific reason and continue with the in-scope work.
 
@@ -632,18 +615,15 @@ STOPPING BECAUSE: all tasks complete, QA passes, daemon restart verified.
 **Why**: The stop hook enforces intentional stops. Stopping without an explanation triggers an auto-block that asks you to explain or continue.
 
 **Alternatives**:
-
 - `STOPPING BECAUSE: <reason>` — stops cleanly with explanation
 - Continue working — no need to stop unless all work is genuinely complete
 
 **Do NOT**:
-
 - Stop mid-task without explanation
 - Ask confirmation questions and then stop (the hook auto-continues those)
 - Use `AUTO-CONTINUE` unless you intend to keep working indefinitely
 
 **Before asking a question, evaluate it critically**:
-
 - Tautological/rhetorical questions with obvious answers ("Should I continue?", "Would you like me to proceed?") — do NOT ask, just do it
 - Errors with a clear next step ("The test failed, should I fix it?") — do NOT ask, just fix it
 - Genuine choice questions where all options are valid ("Which of A, B, or C should we use?") — these deserve a response. Use `STOPPING BECAUSE: need user input` and ask your question
@@ -651,7 +631,6 @@ STOPPING BECAUSE: all tasks complete, QA passes, daemon restart verified.
 **Recovering from a `tool_use_error` — do NOT stop silently**:
 
 Some tool errors require an explicit recovery action, not a halt. The most common shape:
-
 - You call `Edit` or `Write` on a file you have not yet read.
 - Claude Code returns a `tool_use_error` (e.g. "File has not been read yet").
 - The correct recovery is **Read the file, then retry Edit/Write** — **do not stop**. Stopping silently after a tool error triggers a Stop-hook re-entry loop and wastes a turn.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -424,20 +424,6 @@ MUST_STASH_BECAUSE="explain why"; git stash
 
 Configure via `handlers.pre_tool_use.git_stash.options.mode: warn` for advisory-only mode.
 
-## markdown_organization — markdown files must go in allowed locations
-
-Writing a new `.md` file to an unrecognised location is blocked. Markdown files must be placed in project-configured allowed paths.
-
-**Common allowed locations**: `CLAUDE/`, `docs/`, `RELEASES/`, `CLAUDE/Plan/`, root-level `README.md`, or any path matching the `allowed_markdown_paths` config.
-
-**Dependency directories**: `vendor/` (PHP) and `node_modules/` (JS) are treated as implicit monorepos — each package is a sub-project where normal markdown rules apply (e.g. `vendor/acme/lib/docs/guide.md` is allowed, `vendor/acme/lib/random/notes.md` is blocked).
-
-**Plan file redirection**: when `track_plans_in_project` is enabled, Claude Code planning mode writes are automatically redirected to the project's `CLAUDE/Plan/` directory. Plan folders must follow the `NNNN-description/` naming convention.
-
-If you need a markdown file in a new location, add a pattern to `allowed_markdown_paths` in `.claude/hooks-daemon.yaml`.
-
-If your project has sub-projects with their own `docs/`, `CLAUDE/`, etc., configure `monorepo_subproject_patterns` in `.claude/hooks-daemon.yaml` so normal rules apply within each sub-project.
-
 ## pip_break_system — --break-system-packages is blocked
 
 `pip install --break-system-packages` (and the `pip3` / `python -m pip` / `python3 -m pip` variants) is blocked. The flag bypasses PEP 668 system-package protection and corrupts the system Python environment in containers and on modern Linux distros.
@@ -465,6 +451,39 @@ pip install --user <package>
 ```
 
 Even in a container running as root, `sudo` adds nothing — drop it and use a venv.
+
+## ask_user_question_blocker — questions need `ASKING BECAUSE:` justification
+
+AskUserQuestion calls are only allowed when every `question` string begins with `ASKING BECAUSE:` (case-sensitive, leading whitespace OK). The convention mirrors the Stop handler's `STOPPING BECAUSE:` pattern — explicit declared intent gates the privilege of pausing the session.
+
+**Before asking, evaluate critically**:
+- Tautological/rhetorical questions with one obvious answer ("Should I continue?", "Would you like me to proceed?") — do NOT ask. State the question and your assumed-correct answer in plain output text and proceed. The user is watching and will interrupt if the assumption is wrong.
+- Questions whose options reduce to **good vs. bad** are tautological — the answer is always the good option. Examples: best practice vs. bodge, increasing vs. decreasing code quality, delivering the requirement vs. not delivering it, fixing the failing test vs. leaving it broken, following project conventions vs. inventing your own. Do NOT ask; pick the good option and proceed.
+- Errors with a clear recovery path ("Should I fix the failing test?") — do NOT ask. Fix it.
+- Genuine choice questions where you cannot resolve the answer from context — these are the legitimate use case. Prefix every question text with `ASKING BECAUSE: <one-line reason you cannot decide>` so the daemon allows the call through.
+
+**Audit log pattern** (preferred for tautological questions):
+```
+I would normally ask: <question>.
+Assumed answer: <your assumption>.
+Proceeding on that basis; the user will interrupt if wrong.
+```
+
+**Escape hatch** (genuine ambiguity): prefix every question text with `ASKING BECAUSE: <reason>`. Mixing prefixed and non-prefixed questions in one call still triggers a block — prefix all or none.
+
+## markdown_organization — markdown files must go in allowed locations
+
+Writing a new `.md` file to an unrecognised location is blocked. Markdown files must be placed in project-configured allowed paths.
+
+**Common allowed locations**: `CLAUDE/`, `docs/`, `RELEASES/`, `CLAUDE/Plan/`, root-level `README.md`, or any path matching the `allowed_markdown_paths` config.
+
+**Dependency directories**: `vendor/` (PHP) and `node_modules/` (JS) are treated as implicit monorepos — each package is a sub-project where normal markdown rules apply (e.g. `vendor/acme/lib/docs/guide.md` is allowed, `vendor/acme/lib/random/notes.md` is blocked).
+
+**Plan file redirection**: when `track_plans_in_project` is enabled, Claude Code planning mode writes are automatically redirected to the project's `CLAUDE/Plan/` directory. Plan folders must follow the `NNNN-description/` naming convention.
+
+If you need a markdown file in a new location, add a pattern to `allowed_markdown_paths` in `.claude/hooks-daemon.yaml`.
+
+If your project has sub-projects with their own `docs/`, `CLAUDE/`, etc., configure `monorepo_subproject_patterns` in `.claude/hooks-daemon.yaml` so normal rules apply within each sub-project.
 
 ## system_paths — do not edit deployed system files directly
 
@@ -522,6 +541,26 @@ On every new session this handler audits hook configuration across `.claude/sett
 - **Missing hooks**: the daemon's installer writes the full set. If any are missing, re-run `install.py` or manually add the missing `{event_name}` entry pointing at `"$CLAUDE_PROJECT_DIR"/.claude/hooks/{bash-key}`.
 - **Duplicate hooks**: a hook registered in both files fires twice. Keep the `settings.json` entry, delete from `settings.local.json`.
 
+## auto_approve_reads — gated on bypassPermissions mode
+
+Read-only tool permission requests (`Read`, `Glob`, `Grep`) are auto-approved **only** when Claude Code reports `permission_mode == "bypassPermissions"` (YOLO mode).
+
+In every other mode (`default`, `plan`, `acceptEdits`, `dontAsk`) the handler defers and Claude Code's normal approval prompt is shown — the user has not opted out of per-tool approvals, so the daemon must not silently approve on their behalf.
+
+If a permission prompt for `Read` appears in `default` mode, that is correct behaviour — approve it via Claude Code's UI.
+
+## dismissive_language_detector — do not deflect or prematurely halt
+
+Stop-time advisory that fires on language patterns signalling avoidance of work. The handler does NOT block the stop, but injects context for the next turn so the agent self-corrects.
+
+**Avoid**:
+
+- Dismissing issues as `pre-existing`, `out of scope`, `not our problem`,   or `not relevant` to deflect work that is in fact yours.
+- Premature-halt phrasing like `natural checkpoint`, `ready to continue on your   cue`, `pausing here` mid-plan when there is more to do — finish the task   rather than dressing up a halt.
+- Speculative `should be fine` or `probably works` when verification is   cheap (run the test, read the file).
+
+**Do**: acknowledge the issue, fix it, or — if it genuinely is out of scope — say so once with the specific reason and continue with the in-scope work.
+
 ### Stop Explanation Required
 
 Before stopping, **prefix your final message** with `STOPPING BECAUSE:` followed by a clear reason:
@@ -546,16 +585,15 @@ STOPPING BECAUSE: all tasks complete, QA passes, daemon restart verified.
 - Errors with a clear next step ("The test failed, should I fix it?") — do NOT ask, just fix it
 - Genuine choice questions where all options are valid ("Which of A, B, or C should we use?") — these deserve a response. Use `STOPPING BECAUSE: need user input` and ask your question
 
-## dismissive_language_detector — do not deflect or prematurely halt
+**Recovering from a `tool_use_error` — do NOT stop silently**:
 
-Stop-time advisory that fires on language patterns signalling avoidance of work. The handler does NOT block the stop, but injects context for the next turn so the agent self-corrects.
+Some tool errors require an explicit recovery action, not a halt. The most common shape:
+- You call `Edit` or `Write` on a file you have not yet read.
+- Claude Code returns a `tool_use_error` (e.g. "File has not been read yet").
+- The correct recovery is **Read the file, then retry Edit/Write** — **do not stop**. Stopping silently after a tool error triggers a Stop-hook re-entry loop and wastes a turn.
 
-**Avoid**:
+**Rule: Read before Edit/Write.** If you must edit a file you have not read, Read it first in the same turn. The daemon's Stop handler will detect a `tool_use_error` followed by a silent stop and re-fire to force recovery.
 
-- Dismissing issues as `pre-existing`, `out of scope`, `not our problem`,   or `not relevant` to deflect work that is in fact yours.
-- Premature-halt phrasing like `natural checkpoint`, `ready to continue on your   cue`, `pausing here` mid-plan when there is more to do — finish the task   rather than dressing up a halt.
-- Speculative `should be fine` or `probably works` when verification is   cheap (run the test, read the file).
-
-**Do**: acknowledge the issue, fix it, or — if it genuinely is out of scope — say so once with the specific reason and continue with the in-scope work.
+**On Stop hook re-entry (the hook fires again after a prior block)**: your next response is treated like any other — it must either prefix with `STOPPING BECAUSE:` or continue the work. Re-entry does not exempt you from the explanation rule.
 
 </hooksdaemon>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,20 @@ ALL system changes MUST go through Ansible playbooks. Never perform manual file 
 
 **Full IaC workflow (edit → playbook → deploy → test):** @CLAUDE/InfrastructureAsCode.md
 
+### Missing Dependencies — Fail Fast, Fix in IaC
+
+**Never accept a missing dependency. Never paper over it. Surface it loudly and fix it via IaC.**
+
+When a script, QA gate, or workflow errors with "tool not found" (`semgrep not found`, `pdm: command not found`, `which: no foo in …`, etc.):
+
+1. ❌ **DO NOT** install the tool manually (`pipx install foo`, `dnf install foo`, `npm i -g foo`).
+2. ❌ **DO NOT** make the script tolerate the missing tool (skip-if-absent, `|| true`, advisory-only mode).
+3. ❌ **DO NOT** dismiss the gap as "pre-existing environment issue" or "unrelated to this task" — it is now your task.
+4. ✅ **DO** grep the playbooks for an existing install task — if one exists, instruct the user to re-run that play.
+5. ✅ **DO** add the dependency to the relevant playbook if it is missing, then ask the user to run that play.
+
+The host's tool inventory is owned by Ansible. A missing tool is an IaC gap, not a runtime fallback to engineer around. This rule applies to host tools, CCY container tools, and anything else the repo depends on.
+
 ### QA Mandatory Before Commits
 
 Run `./scripts/qa-all.bash` before every commit touching Bash or Python files. Run ESLint for extension JavaScript. Run `./scripts/qa-ctrl-z-patch.bash` for CCY patch changes.
@@ -174,6 +188,7 @@ Piping network content directly to a shell is blocked. It executes untrusted rem
 **Blocked**: `curl URL | bash`, `curl URL | sh`, `wget URL | bash`, `curl URL | sudo bash`
 
 **Safe alternative**: download first, inspect, then execute:
+
 ```
 curl -o /tmp/script.sh URL
 cat /tmp/script.sh          # inspect
@@ -196,6 +211,7 @@ Before making a `git commit` in the hooks daemon repository, this handler advise
 **Blocked**: `chmod 777`, `chmod 666`, `chmod a+w`, `chmod o+w`
 
 **Use least-privilege permissions instead**:
+
 - Executable scripts: `chmod 755` (owner rwx, group/other rx)
 - Regular files: `chmod 644` (owner rw, group/other r)
 - Private files: `chmod 600` (owner rw only)
@@ -204,17 +220,17 @@ Before making a `git commit` in the hooks daemon repository, this handler advise
 
 The following git commands are permanently blocked and will always be denied:
 
-| Command | Reason |
-|---------|--------|
-| `git reset --hard` | Permanently destroys all uncommitted changes |
-| `git clean -f` | Permanently deletes untracked files |
-| `git checkout -- <file>` | Discards all local changes to that file |
-| `git restore <file>` | Discards local changes (`--staged` is allowed) |
-| `git stash drop` | Permanently destroys stashed changes |
-| `git stash clear` | Permanently destroys all stashes |
-| `git push --force` | Can overwrite remote history and destroy teammates' work |
-| `git branch -D` | Force-deletes branch without checking if merged (lowercase `-d` is safe) |
-| `git commit --amend` | Rewrites the previous commit — create a new commit instead |
+| Command                  | Reason                                                                   |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `git reset --hard`       | Permanently destroys all uncommitted changes                             |
+| `git clean -f`           | Permanently deletes untracked files                                      |
+| `git checkout -- <file>` | Discards all local changes to that file                                  |
+| `git restore <file>`     | Discards local changes (`--staged` is allowed)                           |
+| `git stash drop`         | Permanently destroys stashed changes                                     |
+| `git stash clear`        | Permanently destroys all stashes                                         |
+| `git push --force`       | Can overwrite remote history and destroy teammates' work                 |
+| `git branch -D`          | Force-deletes branch without checking if merged (lowercase `-d` is safe) |
+| `git commit --amend`     | Rewrites the previous commit — create a new commit instead               |
 
 If the user needs to run one of these, ask them to do it manually. Do not attempt to work around the block.
 
@@ -225,6 +241,7 @@ If the user needs to run one of these, ask them to do it manually. Do not attemp
 Writing code that silently swallows errors is blocked. All errors must be handled explicitly.
 
 **Blocked patterns (examples)**:
+
 - Python: bare `except` clauses with an empty body, catching and discarding all exceptions
 - Shell: redirecting stderr to `/dev/null` to silence failures, `|| true` to suppress non-zero exit codes
 - JavaScript/TypeScript: empty `catch` blocks that swallow exceptions
@@ -249,6 +266,7 @@ Direct `Write` or `Edit` to package manager lock files is blocked. Lock files ar
 **Blocked files**: `composer.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Gemfile.lock`, `Cargo.lock`, `go.sum`, `Package.resolved`, `Pipfile.lock`, and others.
 
 **Use package manager commands instead**:
+
 - PHP: `composer install` / `composer require package`
 - Node: `npm install` / `yarn add package`
 - Ruby: `bundle install` / `bundle add gem`
@@ -260,6 +278,7 @@ Direct `Write` or `Edit` to package manager lock files is blocked. Lock files ar
 Using `Grep` or `Bash` (grep/rg) to find class definitions, function signatures, or symbol references is blocked or redirected to LSP tools, which are faster and semantically accurate.
 
 **Prefer LSP tools for**:
+
 - Finding where a class or function is defined → `goToDefinition`
 - Finding all usages of a symbol → `findReferences`
 - Getting type information or documentation → `hover`
@@ -304,6 +323,7 @@ pytest tests/ > /tmp/pytest_out.txt 2>&1
 Writing QA suppression directives into source files is blocked across all supported languages. Fix the underlying code issue instead.
 
 **Blocked annotation types (by language)**:
+
 - Python: `noqa` directives, `type: ignore` annotations
 - JavaScript/TypeScript: `eslint-disable` inline directives
 - Go: `nolint` directives (golangci-lint)
@@ -319,6 +339,7 @@ Writing QA suppression directives into source files is blocked across all suppor
 Writing code that contains security antipatterns is blocked across all supported languages. Fix the code to use safe patterns instead.
 
 **Blocked categories**:
+
 - SQL injection: building queries via string concatenation (use parameterised queries)
 - Command injection: passing unvalidated input to subprocess (use argument lists)
 - Hardcoded credentials: API keys, passwords, tokens embedded in source code
@@ -332,15 +353,18 @@ Writing code that contains security antipatterns is blocked across all supported
 `sed` is blocked because Claude gets sed syntax wrong and a single error can silently destroy hundreds of files with no recovery possible.
 
 **Blocked**:
+
 - `sed -i` / `sed -e` (in-place file editing via Bash tool)
 - `grep -rl X | xargs sed -i` (mass file modification)
 - Shell scripts (`.sh`/`.bash`) written via Write tool that contain `sed`
 
 **Allowed** (read-only, no file modification):
+
 - `cat file | sed 's/x/y/' | grep z` (pipeline transforming stdout only)
 - `sed` mentioned in commit messages, PR bodies, or `.md` documentation files
 
 **Use instead**:
+
 - `Edit` tool — safe, atomic, verifiable
 - Parallel Haiku agents with `Edit` tool for bulk changes across many files:
   1. Identify all files to update
@@ -352,6 +376,7 @@ Writing code that contains security antipatterns is blocked across all supported
 Creating a production source file is blocked until a corresponding test file exists.
 
 **TDD workflow (required)**:
+
 1. Create the **test file first** (e.g. `tests/unit/handlers/test_my_handler.py`)
 2. Write failing tests — RED phase
 3. Create the source file and implement until tests pass — GREEN phase
@@ -360,6 +385,7 @@ Creating a production source file is blocked until a corresponding test file exi
 **Supported languages**: Python, Go, JavaScript/TypeScript, PHP, Rust, Java, C#, Kotlin, Ruby, Swift, Dart
 
 **Test file locations checked** (any satisfies the block):
+
 - Separate mirror: `tests/unit/{subdir}/test_{module}.py`
 - Collocated: `{source_dir}/{module}.test.ts` (JS/TS projects)
 - Test subdirectory: `{source_dir}/__tests__/{module}.test.ts`
@@ -371,6 +397,7 @@ Creating a production source file is blocked until a corresponding test file exi
 Writing ephemeral or session-specific content to `CLAUDE.md` or `README.md` is blocked. These files should contain only stable instructions, not implementation logs or session state.
 
 **Blocked content types**:
+
 - Timestamps and ISO dates
 - Status emoji followed by completion words (e.g. checkmark + 'Done')
 - Implementation log sentences ('created the file X', 'added the class Y')
@@ -418,6 +445,7 @@ If using `--json`, include `comments` in the field list instead of adding `--com
 **Why**: stashes get forgotten, lost, and block `git pull`. Use `git commit -m 'WIP: ...'` instead — WIP commits are acceptable.
 
 **Escape hatch** (when commit truly won't work):
+
 ```
 MUST_STASH_BECAUSE="explain why"; git stash
 ```
@@ -457,12 +485,14 @@ Even in a container running as root, `sudo` adds nothing — drop it and use a v
 AskUserQuestion calls are only allowed when every `question` string begins with `ASKING BECAUSE:` (case-sensitive, leading whitespace OK). The convention mirrors the Stop handler's `STOPPING BECAUSE:` pattern — explicit declared intent gates the privilege of pausing the session.
 
 **Before asking, evaluate critically**:
+
 - Tautological/rhetorical questions with one obvious answer ("Should I continue?", "Would you like me to proceed?") — do NOT ask. State the question and your assumed-correct answer in plain output text and proceed. The user is watching and will interrupt if the assumption is wrong.
 - Questions whose options reduce to **good vs. bad** are tautological — the answer is always the good option. Examples: best practice vs. bodge, increasing vs. decreasing code quality, delivering the requirement vs. not delivering it, fixing the failing test vs. leaving it broken, following project conventions vs. inventing your own. Do NOT ask; pick the good option and proceed.
 - Errors with a clear recovery path ("Should I fix the failing test?") — do NOT ask. Fix it.
 - Genuine choice questions where you cannot resolve the answer from context — these are the legitimate use case. Prefix every question text with `ASKING BECAUSE: <one-line reason you cannot decide>` so the daemon allows the call through.
 
 **Audit log pattern** (preferred for tautological questions):
+
 ```
 I would normally ask: <question>.
 Assumed answer: <your assumption>.
@@ -520,6 +550,7 @@ Writing or editing files under system paths (/etc/, /var/, /usr/, /opt/, /root/,
 These are deployed files managed by Ansible.
 
 **Edit the project source instead**:
+
 - `/etc/foo` → `files/etc/foo`
 - `/var/local/foo` → `files/var/local/foo`
 - `/usr/bin/foo` → `files/usr/bin/foo`
@@ -584,9 +615,9 @@ Stop-time advisory that fires on language patterns signalling avoidance of work.
 
 **Avoid**:
 
-- Dismissing issues as `pre-existing`, `out of scope`, `not our problem`,   or `not relevant` to deflect work that is in fact yours.
-- Premature-halt phrasing like `natural checkpoint`, `ready to continue on your   cue`, `pausing here` mid-plan when there is more to do — finish the task   rather than dressing up a halt.
-- Speculative `should be fine` or `probably works` when verification is   cheap (run the test, read the file).
+- Dismissing issues as `pre-existing`, `out of scope`, `not our problem`, or `not relevant` to deflect work that is in fact yours.
+- Premature-halt phrasing like `natural checkpoint`, `ready to continue on your   cue`, `pausing here` mid-plan when there is more to do — finish the task rather than dressing up a halt.
+- Speculative `should be fine` or `probably works` when verification is cheap (run the test, read the file).
 
 **Do**: acknowledge the issue, fix it, or — if it genuinely is out of scope — say so once with the specific reason and continue with the in-scope work.
 
@@ -601,15 +632,18 @@ STOPPING BECAUSE: all tasks complete, QA passes, daemon restart verified.
 **Why**: The stop hook enforces intentional stops. Stopping without an explanation triggers an auto-block that asks you to explain or continue.
 
 **Alternatives**:
+
 - `STOPPING BECAUSE: <reason>` — stops cleanly with explanation
 - Continue working — no need to stop unless all work is genuinely complete
 
 **Do NOT**:
+
 - Stop mid-task without explanation
 - Ask confirmation questions and then stop (the hook auto-continues those)
 - Use `AUTO-CONTINUE` unless you intend to keep working indefinitely
 
 **Before asking a question, evaluate it critically**:
+
 - Tautological/rhetorical questions with obvious answers ("Should I continue?", "Would you like me to proceed?") — do NOT ask, just do it
 - Errors with a clear next step ("The test failed, should I fix it?") — do NOT ask, just fix it
 - Genuine choice questions where all options are valid ("Which of A, B, or C should we use?") — these deserve a response. Use `STOPPING BECAUSE: need user input` and ask your question
@@ -617,6 +651,7 @@ STOPPING BECAUSE: all tasks complete, QA passes, daemon restart verified.
 **Recovering from a `tool_use_error` — do NOT stop silently**:
 
 Some tool errors require an explicit recovery action, not a halt. The most common shape:
+
 - You call `Edit` or `Write` on a file you have not yet read.
 - Claude Code returns a `tool_use_error` (e.g. "File has not been read yet").
 - The correct recovery is **Read the file, then retry Edit/Write** — **do not stop**. Stopping silently after a tool error triggers a Stop-hook re-entry loop and wastes a turn.

--- a/files/var/local/claude-yolo/Dockerfile
+++ b/files/var/local/claude-yolo/Dockerfile
@@ -28,9 +28,16 @@ ARG DOCKERFILE_HASH="unknown"
 # ⚠️  THIS VALUE MUST MATCH REQUIRED_CONTAINER_VERSION in claude-yolo script!
 #     If they don't match, users get infinite rebuild loops.
 #     Update BOTH files together: this label AND the script variable.
-LABEL claude-yolo-version="2.17"
+LABEL claude-yolo-version="2.18"
 LABEL claude-yolo-dockerfile-hash="${DOCKERFILE_HASH}"
 LABEL description="Claude Code YOLO Mode - Isolated container for dangerously-skip-permissions"
+
+# Disable apt's _apt sandbox download user. In rootless podman the chown of
+# cache dirs to _apt fails with EPERM, and the downloaded .deb files are then
+# unreadable to _apt, breaking apt-get install. Running apt downloads as root
+# inside the build container is safe and is the standard workaround for
+# rootless OCI builds on Debian-based base images.
+RUN echo 'APT::Sandbox::User "root";' > /etc/apt/apt.conf.d/no-sandbox
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/files/var/local/claude-yolo/claude-yolo
+++ b/files/var/local/claude-yolo/claude-yolo
@@ -9,7 +9,7 @@
 # The hash validates script integrity - if hash changes but version doesn't,
 # users will get a warning that version wasn't properly updated.
 #
-CCY_VERSION="3.16.1"  # fix(scroll): bump REQUIRED_CONTAINER_VERSION 2.16 → 2.17 to force image rebuild — the entrypoint.sh changes (drop NO_FLICKER, add DISABLE_ALTERNATE_SCREEN kill-switch) bake into the image via COPY but did not trigger a runtime rebuild because the Dockerfile hash itself was unchanged. Bumping the container version forces ccy at next invocation to detect mismatch and rebuild with the new entrypoint. See CLAUDE/Plan/00047/DECISION.md.
+CCY_VERSION="3.16.2"  # fix(build): bump REQUIRED_CONTAINER_VERSION 2.17 → 2.18 alongside Dockerfile change that disables apt's _apt sandbox download user (incompatible with rootless podman after recent host crun/podman upgrade — chown to _apt:root failed with EPERM, breaking all apt installs). Workaround drops apt's privilege-drop and runs downloads as root inside build container, which is safe and is the canonical fix for rootless OCI builds on Debian-based images.
 
 # Load shared helpers
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -36,7 +36,7 @@ done
 # ⚠️  THIS VALUE MUST MATCH the "claude-yolo-version" LABEL in Dockerfile!
 #     If they don't match, users get infinite rebuild loops.
 #     Update BOTH files together: Dockerfile label AND this variable.
-REQUIRED_CONTAINER_VERSION="2.17"
+REQUIRED_CONTAINER_VERSION="2.18"
 
 set -e
 

--- a/playbooks/imports/play-podman.yml
+++ b/playbooks/imports/play-podman.yml
@@ -33,6 +33,91 @@
         scope: user
       when: dbus_session_check.rc == 0
 
+    # =========================================================================
+    # OPT-IN DESTRUCTIVE RECOVERY — wipe rootless podman storage.
+    # =========================================================================
+    #
+    # Skipped by default. Runs ONLY when invoked with:
+    #
+    #     ansible-playbook playbooks/imports/play-podman.yml \
+    #         -e podman_storage_reset=true
+    #
+    # Lives inside play-podman.yml (not as a standalone optional play) so the
+    # generic run.bash / main-playbook flow that offers "run all optional
+    # plays?" cannot ever surface it. Routine podman runs are unaffected.
+    #
+    # When to use:
+    #   - Rootless builds fail with EPERM on chmod/chown/unlink of files from
+    #     a base-image lower layer, even as namespace-root.
+    #   - The failure recurs after `podman system migrate` (the routine task
+    #     just below) has run successfully.
+    #   - chmod of a plain `root:root mode 0755` directory fails inside the
+    #     build — the smoking gun for idmapped-overlay corruption after a
+    #     kernel/podman/crun upgrade.
+    #
+    # Cost: deletes ALL rootless containers, images, volumes, pods, networks
+    # for this user. They can be rebuilt / re-pulled. Does not touch rootful
+    # docker, lxc, or anything outside ~/.local/share/containers and
+    # ~/.config/containers.
+    - name: DESTRUCTIVE — Reset Rootless Podman Storage (opt-in recovery)
+      when: podman_storage_reset | default(false) | bool
+      block:
+        - name: List Rootless Podman Containers
+          ansible.builtin.command: podman ps --all --format '{{ "{{" }}.ID{{ "}}" }}'
+          register: podman_container_list
+          changed_when: false
+
+        - name: Stop All Rootless Podman Containers
+          ansible.builtin.command: "podman stop --ignore --time 5 {{ podman_container_list.stdout_lines | join(' ') }}"
+          when: podman_container_list.stdout_lines | length > 0
+          changed_when: true
+
+        # Reset itself can fail on stale temp-dir files whose UIDs/attributes
+        # the user namespace cannot reach (active overlay mounts, sub-UIDs
+        # outside the current mapping, etc.). Host root can rm anything on
+        # the user's local disk regardless of namespace state.
+        - name: Force-Clean Stale Storage Temp Dirs Before Reset
+          become: true
+          ansible.builtin.file:
+            path: "/home/{{ user_login }}/.local/share/containers/storage/overlay/tempdirs"
+            state: absent
+
+        - name: Reset Rootless Podman Storage
+          ansible.builtin.command: podman system reset --force
+          changed_when: true
+
+        - name: Recovery Notice
+          ansible.builtin.debug:
+            msg: >-
+              Rootless podman storage reset. The 'Migrate Podman User
+              Namespace State' task below will reinitialise the namespace
+              cache. After this play finishes, rebuild downstream images
+              (e.g. ansible-playbook playbooks/imports/play-claude-yolo.yml).
+
+    # After podman / crun / runc / kernel upgrades, the user-namespace storage
+    # state can fall out of sync with the new binaries; symptoms are rootless
+    # builds failing with EPERM in overlay storage (chmod / unlink on lower
+    # layer files inside a build container). `podman system migrate` is the
+    # canonical, idempotent fix — it re-runs the namespace setup. Safe to call
+    # on every play run as long as no containers are currently running.
+    # See https://docs.podman.io/en/latest/markdown/podman-system-migrate.1.html
+    - name: Migrate Podman User Namespace State (post-upgrade fix)
+      ansible.builtin.command: podman system migrate
+      changed_when: false
+
+    # `podman info` walks overlay/tempdirs and fails (rc=125) if any stale
+    # build temp dirs contain files the user cannot unlink (e.g. files from
+    # a half-completed CCY build owned by sub-UIDs the namespace can no
+    # longer reach). The tempdirs/ tree is by definition transient build
+    # scratch — deleting it is safe and idempotent. `podman unshare rm` is
+    # NOT enough on some kernels (it fails when the file UID is outside the
+    # current namespace mapping), so we use host root via passwordless sudo.
+    - name: Clean Stale Rootless Build Temp Dirs (lets podman info succeed)
+      become: true
+      ansible.builtin.file:
+        path: "/home/{{ user_login }}/.local/share/containers/storage/overlay/tempdirs"
+        state: absent
+
     - name: Verify Podman Install
       ansible.builtin.command: podman info
       changed_when: false

--- a/playbooks/imports/play-python.yml
+++ b/playbooks/imports/play-python.yml
@@ -57,6 +57,14 @@
         name: huggingface_hub
         state: latest
 
+    # Required by scripts/qa-patterns.bash (runs .semgrep/bash-conventions.yml rules
+    # against all bash files in the repo). qa-all.bash fails with rc=2 if missing —
+    # see CLAUDE.md "Missing Dependencies" rule (fix via IaC, never tolerate the gap).
+    - name: Semgrep (host-side QA pattern scanner)
+      community.general.pipx:
+        name: semgrep
+        state: latest
+
     - name: Pyenv Python Version Management
       ansible.builtin.shell: |
         curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash


### PR DESCRIPTION
## Summary

Unblocks the CCY rootless podman build after a recent host upgrade. Three layered IaC fixes in `play-podman.yml` + the `claude-yolo` Dockerfile, plus a tangential semgrep dependency fix in `play-python.yml` and a new "Missing Dependencies" rule in CLAUDE.md.

The substantive change is `7b8dda6 fix(ccy): unblock rootless podman build after host crun/podman upgrade`. The other 3 commits on this branch (merge + hooks-daemon regen) are pre-existing work that was already ahead of origin/F43 locally.

### What was broken

After `play-AB-dnf-upgrade` brought in a new podman/crun/kernel combination, `ansible-playbook playbooks/imports/play-claude-yolo.yml` started failing in the image build with `rc=100` and an EPERM cascade — namespace-root could not chmod/unlink even `root:root mode 0755` directories inside the build container, and `podman info` itself was failing on stale overlay/tempdirs/ files owned by sub-UIDs the user namespace can no longer reach.

### Fixes in this PR

- `playbooks/imports/play-podman.yml`

  - Routine cleanup task wipes `~/.local/share/containers/storage/overlay/tempdirs` via host root (`become: true`) before `podman info`. `podman unshare rm` was not enough on these kernels.
  - `podman system migrate` added as a post-upgrade idempotent task.
  - Opt-in destructive recovery added as a guarded task block (NOT a standalone optional play — that would risk auto-discovery by main-run flows). Triggered only by `-e podman_storage_reset=true`.

- `files/var/local/claude-yolo/Dockerfile`

  - Added `APT::Sandbox::User "root"` to `apt.conf.d/no-sandbox`. Rootless podman cannot chown apt cache dirs to `_apt`; making downloads run as root inside the build container is the canonical fix for rootless OCI builds on Debian-based images.

- `files/var/local/claude-yolo/claude-yolo` + Dockerfile label

  - `REQUIRED_CONTAINER_VERSION` and the `claude-yolo-version` label bumped together: `2.17 → 2.18`.
  - `CCY_VERSION` bumped `3.16.1 → 3.16.2`.

- `playbooks/imports/play-python.yml`

  - Added `semgrep` to the existing pipx block (alongside PDM, huggingface_hub). It backs `scripts/qa-patterns.bash` and was missing on host, causing `qa-all.bash` to fail with rc=2.

- `CLAUDE.md`

  - New critical rule "Missing Dependencies — Fail Fast, Fix in IaC" to codify the workflow that uncovered the semgrep gap (no manual installs, no skip-if-absent fallbacks, no "pre-existing env issue" dismissals).

## Test plan

- [ ] `ansible-playbook playbooks/imports/play-python.yml` succeeds and host has `semgrep --version`.
- [ ] `ansible-playbook playbooks/imports/play-podman.yml` succeeds end-to-end; `Verify Podman Install` task does not error on stale tempdirs.
- [ ] `ansible-playbook playbooks/imports/play-claude-yolo.yml` completes the image build to a tagged `claude-yolo:latest` (no EPERM cascade).
- [ ] `./scripts/qa-all.bash` exits 0 on host.
- [ ] CCY can be launched and works against a project.
- [ ] Optional recovery path: `ansible-playbook playbooks/imports/play-podman.yml -e podman_storage_reset=true` wipes storage and reinitialises the namespace cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
