### PR TITLE
docs(plan): drop removed workflow_state handlers from enforcement list

### DIFF
--- a/CLAUDE/Plan/README.md
+++ b/CLAUDE/Plan/README.md
@@ -109,8 +109,6 @@ The hooks daemon enforces plan workflow standards:
 - ✅ `validate_plan_number` - Ensures correct numbering format
 - ✅ `plan_time_estimates` - Blocks time estimates in plans
 - ✅ `plan_workflow` - Provides guidance when creating plans
-- ✅ `workflow_state_pre_compact` - Saves workflow state before compaction
-- ✅ `workflow_state_restoration` - Restores state after compaction
 
 ## References
 


### PR DESCRIPTION
## Summary

Removes two stale handler entries from the Plan README's workflow enforcement list. The `workflow_state_pre_compact` and `workflow_state_restoration` handlers are no longer part of the plan workflow enforcement set, so their entries in `CLAUDE/Plan/README.md` were out of date.

## Changes

- `CLAUDE/Plan/README.md` — remove the two obsolete `workflow_state_*` handler bullets (2 deletions).

## Notes

Documentation-only change. No Bash/Python/Ansible files touched, so QA suite not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)