### PR TITLE
fix(github-cli-multi): skip live SSH verification under --check

### DIFF
--- a/playbooks/imports/play-github-cli-multi.yml
+++ b/playbooks/imports/play-github-cli-multi.yml
@@ -449,6 +449,11 @@
           register: ssh_test
           changed_when: false
           failed_when: ssh_test.rc not in [0, 1, 124, 255]
+          # Live SSH auth cannot run under --check: the passphrase file and
+          # any generated keys are side-effect tasks that are skipped in check
+          # mode, leaving this probe with empty stdout. Skip it (and the assert
+          # below) rather than fail spuriously on a dry run.
+          when: not ansible_check_mode
           loop: "{{ github_accounts | default({}) | dict2items }}"
           loop_control:
             label: "{{ item.key }}"
@@ -458,11 +463,13 @@
             msg: >
               github_{{ item.item.key }} (expects {{ item.item.value }}):
               {{ item.stdout | regex_search('Hi [^!]+!') | default('NOT AUTHENTICATED', true) }}
-          loop: "{{ ssh_test.results }}"
+          when: not ansible_check_mode
+          loop: "{{ ssh_test.results | default([]) }}"
           loop_control:
             label: "{{ item.item.key }}"
 
         - name: Assert SSH access and identity match for all accounts
+          when: not ansible_check_mode
           ansible.builtin.assert:
             that:
               - "'successfully authenticated' in item.stdout"
@@ -483,7 +490,7 @@
                 rm ~/.ssh/github_{{ item.item.key }} ~/.ssh/github_{{ item.item.key }}.pub
                 # then re-run this playbook
             success_msg: "{{ item.item.key }} -> {{ item.item.value }} OK"
-          loop: "{{ ssh_test.results }}"
+          loop: "{{ ssh_test.results | default([]) }}"
           loop_control:
             label: "{{ item.item.key }}"
 


### PR DESCRIPTION
## Problem

Running the play with `--check` failed at **Assert SSH access and identity match for all accounts** with a misleading "passphrase-related" diagnosis for every account:

```
SSH verification FAILED for alias balli (expected user tahir-ec-ballicom).
GitHub responded: (no Hi response)
... most likely passphrase-related.
```

This was a **check-mode false failure**, not a real passphrase issue. The failed items show the smoking gun:

```
"skipped": true,  "rc": 0,  "stdout": "",
"msg": "Command would have run if not in check mode"
```

## Root cause

The `Verify SSH access` task is a read-only SSH probe (`changed_when: false`), but it depends on side-effecting tasks that Ansible skips in check mode:
- the passphrase file `/tmp/.github_ssh_pp` (created by a `copy` task)
- key generation

In check mode the probe is skipped, so `item.stdout` is empty, and the downstream `assert` (`'successfully authenticated' in item.stdout`) fails — printing the misleading passphrase remediation.

## Fix

- Guard the verify / display / assert tasks with `when: not ansible_check_mode` — a dry run cannot perform live SSH auth anyway, so it now skips cleanly instead of failing spuriously.
- Harden the loops with `| default([])` so they no-op when the probe is skipped.

## Verification

- `./scripts/qa-all.bash` → passes
- `ansible-playbook ... --syntax-check` → exit 0
- YAML parse → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)