### PR TITLE
chore: sync auto-generated CLAUDE.md hooks-daemon guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,25 @@ The `Read`, `Write`, and `Edit` tools require absolute paths. Relative paths are
 
 The working directory is `/workspace`. Prepend `/workspace/` to any relative path before calling these tools.
 
+## ask_user_question_blocker — questions need `ASKING BECAUSE:` justification
+
+AskUserQuestion calls are only allowed when every `question` string begins with `ASKING BECAUSE:` (case-sensitive, leading whitespace OK). The convention mirrors the Stop handler's `STOPPING BECAUSE:` pattern — explicit declared intent gates the privilege of pausing the session.
+
+**Before asking, evaluate critically**:
+- Tautological/rhetorical questions with one obvious answer ("Should I continue?", "Would you like me to proceed?") — do NOT ask. State the question and your assumed-correct answer in plain output text and proceed. The user is watching and will interrupt if the assumption is wrong.
+- Questions whose options reduce to **good vs. bad** are tautological — the answer is always the good option. Examples: best practice vs. bodge, increasing vs. decreasing code quality, delivering the requirement vs. not delivering it, fixing the failing test vs. leaving it broken, following project conventions vs. inventing your own. Do NOT ask; pick the good option and proceed.
+- Errors with a clear recovery path ("Should I fix the failing test?") — do NOT ask. Fix it.
+- Genuine choice questions where you cannot resolve the answer from context — these are the legitimate use case. Prefix every question text with `ASKING BECAUSE: <one-line reason you cannot decide>` so the daemon allows the call through.
+
+**Audit log pattern** (preferred for tautological questions):
+```
+I would normally ask: <question>.
+Assumed answer: <your assumption>.
+Proceeding on that basis; the user will interrupt if wrong.
+```
+
+**Escape hatch** (genuine ambiguity): prefix every question text with `ASKING BECAUSE: <reason>`. Mixing prefixed and non-prefixed questions in one call still triggers a block — prefix all or none.
+
 ## curl_pipe_shell — never pipe curl/wget to bash/sh
 
 Piping network content directly to a shell is blocked. It executes untrusted remote code without any inspection.
@@ -196,6 +215,20 @@ curl -o /tmp/script.sh URL
 cat /tmp/script.sh          # inspect
 bash /tmp/script.sh         # execute if safe
 ```
+
+## daemon_location_guard — do not cd into .claude/hooks-daemon/
+
+Bash commands that change directory into `.claude/hooks-daemon/` (or `cd` into a daemon-internal subdirectory and then run something) are blocked. The daemon is an upstream dependency that must remain untouched in client repos.
+
+**Run daemon CLI from the project root instead** — it always works regardless of cwd:
+
+```
+$PYTHON -m claude_code_hooks_daemon.daemon.cli status
+$PYTHON -m claude_code_hooks_daemon.daemon.cli restart
+$PYTHON -m claude_code_hooks_daemon.daemon.cli logs
+```
+
+If you need to inspect daemon source for debugging, use `Read` from the project root with the absolute path — never `cd` in. Do NOT edit anything inside `.claude/hooks-daemon/`; changes will be overwritten on the next upgrade.
 
 ## daemon_restart_verifier — restart the daemon before committing
 
@@ -249,6 +282,52 @@ Writing code that silently swallows errors is blocked. All errors must be handle
 
 **Required action**: Handle errors explicitly — log them, return them to the caller, or propagate them. Silent error suppression masks bugs and makes debugging impossible.
 
+## gh_issue_comments — always include --comments on gh issue view
+
+`gh issue view` without `--comments` is blocked. Issue comments often contain critical context, clarifications, and updates not in the issue body.
+
+**Blocked**: `gh issue view 123`, `gh issue view 123 --repo owner/repo`
+
+**Allowed**: `gh issue view 123 --comments`, `gh issue view 123 --json title,body,comments`
+
+If using `--json`, include `comments` in the field list instead of adding `--comments`.
+
+## gh_pr_comments — always include --comments on gh pr view
+
+`gh pr view` without `--comments` is blocked. PR comments often contain review feedback, reviewer requests, and decisions not in the PR body.
+
+**Blocked**: `gh pr view 123`, `gh pr view 123 --repo owner/repo`
+
+**Allowed**: `gh pr view 123 --comments`, `gh pr view 123 --json title,body,comments`
+
+If using `--json`, include `comments` in the field list instead of adding `--comments`.
+
+## git_stash — git stash is blocked by default
+
+`git stash`, `git stash push`, and `git stash save` are blocked. `git stash pop`, `git stash apply`, `git stash list`, and `git stash show` are always allowed.
+
+**Why**: stashes get forgotten, lost, and block `git pull`. Use `git commit -m 'WIP: ...'` instead — WIP commits are acceptable.
+
+**Escape hatch** (when commit truly won't work):
+```
+MUST_STASH_BECAUSE="explain why"; git stash
+```
+
+Configure via `handlers.pre_tool_use.git_stash.options.mode: warn` for advisory-only mode.
+
+## lock_file_edit_blocker — never directly edit lock files
+
+Direct `Write` or `Edit` to package manager lock files is blocked. Lock files are generated artifacts; manual edits create checksum mismatches and broken dependency graphs.
+
+**Blocked files**: `composer.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Gemfile.lock`, `Cargo.lock`, `go.sum`, `Package.resolved`, `Pipfile.lock`, and others.
+
+**Use package manager commands instead**:
+- PHP: `composer install` / `composer require package`
+- Node: `npm install` / `yarn add package`
+- Ruby: `bundle install` / `bundle add gem`
+- Rust: `cargo add crate`
+- Go: `go get module`
+
 ## lsp_enforcement — use LSP tools for code symbol lookups
 
 Using `Grep` or `Bash` (grep/rg) to find class definitions, function signatures, or symbol references is blocked or redirected to LSP tools, which are faster and semantically accurate.
@@ -263,6 +342,107 @@ Using `Grep` or `Bash` (grep/rg) to find class definitions, function signatures,
 **Grep/Bash grep is still appropriate for**: text patterns in content, log searching, finding strings in config files.
 
 Default mode (`block_once`): the first symbol-lookup grep in a session is denied with guidance; subsequent retries are allowed.
+
+## markdown_organization — markdown files must go in allowed locations
+
+Writing a new `.md` file to an unrecognised location is blocked. Markdown files must be placed in project-configured allowed paths.
+
+**Common allowed locations**: `CLAUDE/`, `docs/`, `RELEASES/`, `CLAUDE/Plan/`, root-level `README.md`, or any path matching the `allowed_markdown_paths` config.
+
+**Dependency directories**: `vendor/` (PHP) and `node_modules/` (JS) are treated as implicit monorepos — each package is a sub-project where normal markdown rules apply (e.g. `vendor/acme/lib/docs/guide.md` is allowed, `vendor/acme/lib/random/notes.md` is blocked).
+
+**Plan file redirection**: when `track_plans_in_project` is enabled, Claude Code planning mode writes are automatically redirected to the project's `CLAUDE/Plan/` directory. Plan folders must follow the `NNNN-description/` naming convention.
+
+If you need a markdown file in a new location, add a pattern to `extra_allowed_markdown_paths` in `.claude/hooks-daemon.yaml`. This is ADDITIVE — it layers your patterns on top of the built-in defaults, so you keep `CLAUDE/`, `docs/`, `RELEASES/`, etc. without redeclaring them. The older `allowed_markdown_paths` option REPLACES all built-in locations and is discouraged for simple additions.
+
+If your project has sub-projects with their own `docs/`, `CLAUDE/`, etc., configure `monorepo_subproject_patterns` in `.claude/hooks-daemon.yaml` so normal rules apply within each sub-project.
+
+## npm_command — use llm: prefixed npm commands
+
+Direct `npm run` and `npx` commands are blocked or advised against. Projects with `llm:` prefixed scripts in `package.json` should use those instead.
+
+**Why**: `llm:` commands are configured for LLM-friendly output (no spinners, no colour codes, structured results).
+
+**Example**: Use `npm run llm:build` instead of `npm run build`.
+
+If no `llm:` commands exist in `package.json`, the handler operates in advisory mode (warns but does not block).
+
+## pip_break_system — --break-system-packages is blocked
+
+`pip install --break-system-packages` (and the `pip3` / `python -m pip` / `python3 -m pip` variants) is blocked. The flag bypasses PEP 668 system-package protection and corrupts the system Python environment in containers and on modern Linux distros.
+
+**Use a virtualenv or `--user` install instead**:
+
+```
+python3 -m venv /tmp/venv && /tmp/venv/bin/pip install <package>
+# or
+pip install --user <package>
+```
+
+If a tool's installer insists on `--break-system-packages` (some quick-start scripts do), download it first, inspect, and run it inside a venv — do not shortcut by adding the flag.
+
+### Pipe Blocker
+
+Commands piped to `tail` or `head` are **blocked** — piping truncates output and causes information loss.
+
+**Use a temp file instead:**
+
+```bash
+# WRONG — blocked:
+pytest tests/ 2>&1 | tail -20
+
+# RIGHT — redirect to temp file:
+pytest tests/ > /tmp/pytest_out.txt 2>&1
+# Then read selectively if needed
+```
+
+**Allowed** (whitelisted): `grep`, `rg`, `awk`, `sed`, `jq`, `ls`, `cat`, `git log`, `git tag`, `git branch`, and other cheap filtering commands.
+
+**Add to whitelist** (if safe to pipe): set `extra_whitelist` in `.claude/hooks-daemon.yaml` under `pipe_blocker`.
+
+## plan_number_helper — the git counter is the source of truth for plan numbers
+
+The next plan number is authoritative in git config, NOT in the folder listing.
+
+**To get the next plan number:**
+
+```
+git config --local hooksdaemon.latestPlanNumber
+```
+
+Add 1 to that value — that is the next plan number (zero-pad to 5 digits, e.g. counter `117` → next plan `00118`). The daemon updates this counter automatically whenever a plan is created, so it stays correct across branches.
+
+**Do NOT** scan `CLAUDE/Plan/` with `ls`/`find`/glob pipelines to discover the next number. Folder scans miss plans in `Completed/` and other subdirectories, and disagree across branches. The folder scan is only a fallback used to bootstrap the counter when the git key is unset.
+
+If the counter key is missing (unset), it is safe to bootstrap once from the highest `NNNNN-` prefix under `CLAUDE/Plan/` (including `Completed/`); the daemon persists it back to git config for subsequent reads.
+
+## plan_time_estimates — plans describe WHAT, not WHEN
+
+Writing time estimates into a `CLAUDE/Plan/*.md` file is blocked. Plans capture the work to be done, not how long it will take.
+
+**Blocked in plan documents:**
+
+- Effort estimates — `**Estimated Effort**: 4 hours`, `Total Estimated Time: 2 days`
+- Per-phase durations — `Phase 1: ... (3 days)`, `takes 8-12 hours`
+- Target/completion dates — `**Target Completion**: 2026-06-30`, `Completion: 2026-06-30`
+- `ETA:`, `timeline:`, `deadline:`, `due date:` lines
+
+**Instead:** break work into concrete tasks and implementation steps, and let the user decide scheduling. Technical durations that describe a feature (cache TTL, session timeout, retention window) are allowed — only work/effort estimates are blocked.
+
+## qa_suppression — QA suppression annotations are blocked
+
+Writing QA suppression directives into source files is blocked across all supported languages. Fix the underlying code issue instead.
+
+**Blocked annotation types (by language)**:
+- Python: `noqa` directives, `type: ignore` annotations
+- JavaScript/TypeScript: `eslint-disable` inline directives
+- Go: `nolint` directives (golangci-lint)
+- PHP: `phpstan-ignore`, `psalm-suppress` annotations
+- Java/Kotlin: `@SuppressWarnings`, `@Suppress` annotations
+- C#: `pragma warning disable` directives
+- Rust: `allow(clippy::...)` attributes on type-level items
+
+**Required action**: Fix the code so QA passes without suppression. If a suppression is genuinely necessary, ask the user to add it manually — this signals a conscious decision rather than a shortcut.
 
 ## security_antipattern — OWASP security antipatterns are blocked
 
@@ -296,6 +476,20 @@ Writing code that contains security antipatterns is blocked across all supported
   1. Identify all files to update
   2. Dispatch one Haiku agent per file
   3. Each agent uses the `Edit` tool (never `sed`)
+
+## sudo_pip — sudo pip install is blocked
+
+`sudo pip install` (and the `sudo pip3` / `sudo python -m pip` / `sudo python3 -m pip` variants) is blocked. Installing as root corrupts the system Python managed by the OS package manager and creates permission/ownership issues that are painful to recover from.
+
+**Use a virtualenv or `--user` install instead**:
+
+```
+python3 -m venv /tmp/venv && /tmp/venv/bin/pip install <package>
+# or
+pip install --user <package>
+```
+
+Even in a container running as root, `sudo` adds nothing — drop it and use a venv.
 
 ## tdd_enforcement — test file must exist before source file
 
@@ -337,200 +531,6 @@ Worktrees are isolated branches. Cross-copying corrupts that isolation and can s
 
 **Allowed**: operations within the same worktree branch. **To merge changes**: use `git merge` or `git cherry-pick` instead.
 
-## gh_issue_comments — always include --comments on gh issue view
-
-`gh issue view` without `--comments` is blocked. Issue comments often contain critical context, clarifications, and updates not in the issue body.
-
-**Blocked**: `gh issue view 123`, `gh issue view 123 --repo owner/repo`
-
-**Allowed**: `gh issue view 123 --comments`, `gh issue view 123 --json title,body,comments`
-
-If using `--json`, include `comments` in the field list instead of adding `--comments`.
-
-## lock_file_edit_blocker — never directly edit lock files
-
-Direct `Write` or `Edit` to package manager lock files is blocked. Lock files are generated artifacts; manual edits create checksum mismatches and broken dependency graphs.
-
-**Blocked files**: `composer.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `Gemfile.lock`, `Cargo.lock`, `go.sum`, `Package.resolved`, `Pipfile.lock`, and others.
-
-**Use package manager commands instead**:
-- PHP: `composer install` / `composer require package`
-- Node: `npm install` / `yarn add package`
-- Ruby: `bundle install` / `bundle add gem`
-- Rust: `cargo add crate`
-- Go: `go get module`
-
-## npm_command — use llm: prefixed npm commands
-
-Direct `npm run` and `npx` commands are blocked or advised against. Projects with `llm:` prefixed scripts in `package.json` should use those instead.
-
-**Why**: `llm:` commands are configured for LLM-friendly output (no spinners, no colour codes, structured results).
-
-**Example**: Use `npm run llm:build` instead of `npm run build`.
-
-If no `llm:` commands exist in `package.json`, the handler operates in advisory mode (warns but does not block).
-
-### Pipe Blocker
-
-Commands piped to `tail` or `head` are **blocked** — piping truncates output and causes information loss.
-
-**Use a temp file instead:**
-
-```bash
-# WRONG — blocked:
-pytest tests/ 2>&1 | tail -20
-
-# RIGHT — redirect to temp file:
-pytest tests/ > /tmp/pytest_out.txt 2>&1
-# Then read selectively if needed
-```
-
-**Allowed** (whitelisted): `grep`, `rg`, `awk`, `sed`, `jq`, `ls`, `cat`, `git log`, `git tag`, `git branch`, and other cheap filtering commands.
-
-**Add to whitelist** (if safe to pipe): set `extra_whitelist` in `.claude/hooks-daemon.yaml` under `pipe_blocker`.
-
-## qa_suppression — QA suppression annotations are blocked
-
-Writing QA suppression directives into source files is blocked across all supported languages. Fix the underlying code issue instead.
-
-**Blocked annotation types (by language)**:
-- Python: `noqa` directives, `type: ignore` annotations
-- JavaScript/TypeScript: `eslint-disable` inline directives
-- Go: `nolint` directives (golangci-lint)
-- PHP: `phpstan-ignore`, `psalm-suppress` annotations
-- Java/Kotlin: `@SuppressWarnings`, `@Suppress` annotations
-- C#: `pragma warning disable` directives
-- Rust: `allow(clippy::...)` attributes on type-level items
-
-**Required action**: Fix the code so QA passes without suppression. If a suppression is genuinely necessary, ask the user to add it manually — this signals a conscious decision rather than a shortcut.
-
-## git_stash — git stash is blocked by default
-
-`git stash`, `git stash push`, and `git stash save` are blocked. `git stash pop`, `git stash apply`, `git stash list`, and `git stash show` are always allowed.
-
-**Why**: stashes get forgotten, lost, and block `git pull`. Use `git commit -m 'WIP: ...'` instead — WIP commits are acceptable.
-
-**Escape hatch** (when commit truly won't work):
-```
-MUST_STASH_BECAUSE="explain why"; git stash
-```
-
-Configure via `handlers.pre_tool_use.git_stash.options.mode: warn` for advisory-only mode.
-
-## gh_pr_comments — always include --comments on gh pr view
-
-`gh pr view` without `--comments` is blocked. PR comments often contain review feedback, reviewer requests, and decisions not in the PR body.
-
-**Blocked**: `gh pr view 123`, `gh pr view 123 --repo owner/repo`
-
-**Allowed**: `gh pr view 123 --comments`, `gh pr view 123 --json title,body,comments`
-
-If using `--json`, include `comments` in the field list instead of adding `--comments`.
-
-## daemon_location_guard — do not cd into .claude/hooks-daemon/
-
-Bash commands that change directory into `.claude/hooks-daemon/` (or `cd` into a daemon-internal subdirectory and then run something) are blocked. The daemon is an upstream dependency that must remain untouched in client repos.
-
-**Run daemon CLI from the project root instead** — it always works regardless of cwd:
-
-```
-$PYTHON -m claude_code_hooks_daemon.daemon.cli status
-$PYTHON -m claude_code_hooks_daemon.daemon.cli restart
-$PYTHON -m claude_code_hooks_daemon.daemon.cli logs
-```
-
-If you need to inspect daemon source for debugging, use `Read` from the project root with the absolute path — never `cd` in. Do NOT edit anything inside `.claude/hooks-daemon/`; changes will be overwritten on the next upgrade.
-
-## pip_break_system — --break-system-packages is blocked
-
-`pip install --break-system-packages` (and the `pip3` / `python -m pip` / `python3 -m pip` variants) is blocked. The flag bypasses PEP 668 system-package protection and corrupts the system Python environment in containers and on modern Linux distros.
-
-**Use a virtualenv or `--user` install instead**:
-
-```
-python3 -m venv /tmp/venv && /tmp/venv/bin/pip install <package>
-# or
-pip install --user <package>
-```
-
-If a tool's installer insists on `--break-system-packages` (some quick-start scripts do), download it first, inspect, and run it inside a venv — do not shortcut by adding the flag.
-
-## sudo_pip — sudo pip install is blocked
-
-`sudo pip install` (and the `sudo pip3` / `sudo python -m pip` / `sudo python3 -m pip` variants) is blocked. Installing as root corrupts the system Python managed by the OS package manager and creates permission/ownership issues that are painful to recover from.
-
-**Use a virtualenv or `--user` install instead**:
-
-```
-python3 -m venv /tmp/venv && /tmp/venv/bin/pip install <package>
-# or
-pip install --user <package>
-```
-
-Even in a container running as root, `sudo` adds nothing — drop it and use a venv.
-
-## ask_user_question_blocker — questions need `ASKING BECAUSE:` justification
-
-AskUserQuestion calls are only allowed when every `question` string begins with `ASKING BECAUSE:` (case-sensitive, leading whitespace OK). The convention mirrors the Stop handler's `STOPPING BECAUSE:` pattern — explicit declared intent gates the privilege of pausing the session.
-
-**Before asking, evaluate critically**:
-- Tautological/rhetorical questions with one obvious answer ("Should I continue?", "Would you like me to proceed?") — do NOT ask. State the question and your assumed-correct answer in plain output text and proceed. The user is watching and will interrupt if the assumption is wrong.
-- Questions whose options reduce to **good vs. bad** are tautological — the answer is always the good option. Examples: best practice vs. bodge, increasing vs. decreasing code quality, delivering the requirement vs. not delivering it, fixing the failing test vs. leaving it broken, following project conventions vs. inventing your own. Do NOT ask; pick the good option and proceed.
-- Errors with a clear recovery path ("Should I fix the failing test?") — do NOT ask. Fix it.
-- Genuine choice questions where you cannot resolve the answer from context — these are the legitimate use case. Prefix every question text with `ASKING BECAUSE: <one-line reason you cannot decide>` so the daemon allows the call through.
-
-**Audit log pattern** (preferred for tautological questions):
-```
-I would normally ask: <question>.
-Assumed answer: <your assumption>.
-Proceeding on that basis; the user will interrupt if wrong.
-```
-
-**Escape hatch** (genuine ambiguity): prefix every question text with `ASKING BECAUSE: <reason>`. Mixing prefixed and non-prefixed questions in one call still triggers a block — prefix all or none.
-
-## plan_number_helper — the git counter is the source of truth for plan numbers
-
-The next plan number is authoritative in git config, NOT in the folder listing.
-
-**To get the next plan number:**
-
-```
-git config --local hooksdaemon.latestPlanNumber
-```
-
-Add 1 to that value — that is the next plan number (zero-pad to 5 digits, e.g. counter `117` → next plan `00118`). The daemon updates this counter automatically whenever a plan is created, so it stays correct across branches.
-
-**Do NOT** scan `CLAUDE/Plan/` with `ls`/`find`/glob pipelines to discover the next number. Folder scans miss plans in `Completed/` and other subdirectories, and disagree across branches. The folder scan is only a fallback used to bootstrap the counter when the git key is unset.
-
-If the counter key is missing (unset), it is safe to bootstrap once from the highest `NNNNN-` prefix under `CLAUDE/Plan/` (including `Completed/`); the daemon persists it back to git config for subsequent reads.
-
-## plan_time_estimates — plans describe WHAT, not WHEN
-
-Writing time estimates into a `CLAUDE/Plan/*.md` file is blocked. Plans capture the work to be done, not how long it will take.
-
-**Blocked in plan documents:**
-
-- Effort estimates — `**Estimated Effort**: 4 hours`, `Total Estimated Time: 2 days`
-- Per-phase durations — `Phase 1: ... (3 days)`, `takes 8-12 hours`
-- Target/completion dates — `**Target Completion**: 2026-06-30`, `Completion: 2026-06-30`
-- `ETA:`, `timeline:`, `deadline:`, `due date:` lines
-
-**Instead:** break work into concrete tasks and implementation steps, and let the user decide scheduling. Technical durations that describe a feature (cache TTL, session timeout, retention window) are allowed — only work/effort estimates are blocked.
-
-## markdown_organization — markdown files must go in allowed locations
-
-Writing a new `.md` file to an unrecognised location is blocked. Markdown files must be placed in project-configured allowed paths.
-
-**Common allowed locations**: `CLAUDE/`, `docs/`, `RELEASES/`, `CLAUDE/Plan/`, root-level `README.md`, or any path matching the `allowed_markdown_paths` config.
-
-**Dependency directories**: `vendor/` (PHP) and `node_modules/` (JS) are treated as implicit monorepos — each package is a sub-project where normal markdown rules apply (e.g. `vendor/acme/lib/docs/guide.md` is allowed, `vendor/acme/lib/random/notes.md` is blocked).
-
-**Plan file redirection**: when `track_plans_in_project` is enabled, Claude Code planning mode writes are automatically redirected to the project's `CLAUDE/Plan/` directory. Plan folders must follow the `NNNN-description/` naming convention.
-
-If you need a markdown file in a new location, add a pattern to `extra_allowed_markdown_paths` in `.claude/hooks-daemon.yaml`. This is ADDITIVE — it layers your patterns on top of the built-in defaults, so you keep `CLAUDE/`, `docs/`, `RELEASES/`, etc. without redeclaring them. The older `allowed_markdown_paths` option REPLACES all built-in locations and is discouraged for simple additions.
-
-If your project has sub-projects with their own `docs/`, `CLAUDE/`, etc., configure `monorepo_subproject_patterns` in `.claude/hooks-daemon.yaml` so normal rules apply within each sub-project.
-
 ## system_paths — do not edit deployed system files directly
 
 Writing or editing files under system paths (/etc/, /var/, /usr/, /opt/, /root/, /home/) is blocked.
@@ -553,6 +553,10 @@ Direct package management, service management, and system configuration commands
 
 **Use instead**: Create/update Ansible playbook in `playbooks/imports/` and deploy with `ansible-playbook`.
 
+## git_hooks_executable_fixer — auto-fixes non-executable git hooks
+
+When a git command prints `hint: The '...' hook was ignored because it's not set as executable`, this handler automatically `chmod +x`s every non-`.sample` file in the repository's hooks directory (resolved via `git rev-parse --git-path hooks`, so worktrees and `core.hooksPath` are handled). Execute bits are added with least privilege (only where read is already granted). It never blocks the command and reports which hooks it fixed via advisory context. `.sample` files and already-executable hooks are left untouched.
+
 ## markdown_table_formatter — markdown tables are auto-aligned
 
 After every `Write` or `Edit` of a `.md` or `.markdown` file, the content is re-formatted via `mdformat + mdformat-gfm` so that table pipes are aligned and column widths are consistent. The handler is non-terminal and advisory — it never blocks, it just rewrites the file on disk.
@@ -569,10 +573,6 @@ After every `Write` or `Edit` of a `.md` or `.markdown` file, the content is re-
 ```
 $PYTHON -m claude_code_hooks_daemon.daemon.cli format-markdown <path>
 ```
-
-## git_hooks_executable_fixer — auto-fixes non-executable git hooks
-
-When a git command prints `hint: The '...' hook was ignored because it's not set as executable`, this handler automatically `chmod +x`s every non-`.sample` file in the repository's hooks directory (resolved via `git rev-parse --git-path hooks`, so worktrees and `core.hooksPath` are handled). Execute bits are added with least privilege (only where read is already granted). It never blocks the command and reports which hooks it fixed via advisory context. `.sample` files and already-executable hooks are left untouched.
 
 ## hook_registration_checker — hooks configuration policy
 
@@ -598,18 +598,6 @@ Read-only tool permission requests (`Read`, `Glob`, `Grep`) are auto-approved **
 In every other mode (`default`, `plan`, `acceptEdits`, `dontAsk`) the handler defers and Claude Code's normal approval prompt is shown — the user has not opted out of per-tool approvals, so the daemon must not silently approve on their behalf.
 
 If a permission prompt for `Read` appears in `default` mode, that is correct behaviour — approve it via Claude Code's UI.
-
-## dismissive_language_detector — do not deflect or prematurely halt
-
-Stop-time advisory that fires on language patterns signalling avoidance of work. The handler does NOT block the stop, but injects context for the next turn so the agent self-corrects.
-
-**Avoid**:
-
-- Dismissing issues as `pre-existing`, `out of scope`, `not our problem`,   or `not relevant` to deflect work that is in fact yours.
-- Premature-halt phrasing like `natural checkpoint`, `ready to continue on your   cue`, `pausing here` mid-plan when there is more to do — finish the task   rather than dressing up a halt.
-- Speculative `should be fine` or `probably works` when verification is   cheap (run the test, read the file).
-
-**Do**: acknowledge the issue, fix it, or — if it genuinely is out of scope — say so once with the specific reason and continue with the in-scope work.
 
 ### Stop Explanation Required
 
@@ -645,5 +633,17 @@ Some tool errors require an explicit recovery action, not a halt. The most commo
 **Rule: Read before Edit/Write.** If you must edit a file you have not read, Read it first in the same turn. The daemon's Stop handler will detect a `tool_use_error` followed by a silent stop and re-fire to force recovery.
 
 **On Stop hook re-entry (the hook fires again after a prior block)**: your next response is treated like any other — it must either prefix with `STOPPING BECAUSE:` or continue the work. Re-entry does not exempt you from the explanation rule.
+
+## dismissive_language_detector — do not deflect or prematurely halt
+
+Stop-time advisory that fires on language patterns signalling avoidance of work. The handler does NOT block the stop, but injects context for the next turn so the agent self-corrects.
+
+**Avoid**:
+
+- Dismissing issues as `pre-existing`, `out of scope`, `not our problem`,   or `not relevant` to deflect work that is in fact yours.
+- Premature-halt phrasing like `natural checkpoint`, `ready to continue on your   cue`, `pausing here` mid-plan when there is more to do — finish the task   rather than dressing up a halt.
+- Speculative `should be fine` or `probably works` when verification is   cheap (run the test, read the file).
+
+**Do**: acknowledge the issue, fix it, or — if it genuinely is out of scope — say so once with the specific reason and continue with the in-scope work.
 
 </hooksdaemon>


### PR DESCRIPTION
## Summary

Syncs the auto-generated **hooks-daemon handler guidance** block in `CLAUDE.md` to its current canonical form, plus the merge of the port-443 docs that already landed on `F44`.

This branch carries the local commits that were ahead of `origin/F44`:

- `6f0f9df` — hooks daemon regenerated `CLAUDE.md` handler guidance (auto-generated)
- `215e551` — merge of `origin/F44` (the `--github-443` docs follow-up)

## Net change vs F44

Only `CLAUDE.md` — a regeneration of the daemon-managed `<hooksdaemon>` section (186/186 line reshuffle, no behavioural change). The section is marked *"Auto-generated by hooks daemon on restart. Do not edit."*

## Context

The GitHub-SSH-over-443 feature itself (`086eb62`, `a4203db`) is already on `F44`; this PR is just the trailing auto-generated `CLAUDE.md` sync, opened from a fork since the author lacks direct push access.

## Verification

- `git pull` / `git fetch` / `git push` all exercised successfully over `ssh.github.com:443` on a port-22-blocked network (the scenario the 443 feature exists for).
- No Bash/Python/Ansible source touched, so `qa-all.bash` is not implicated; the only changed file is the daemon-generated `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
