### PR TITLE
server profile: fix desktop assumptions that abort headless/Cloud runs

### DIFF
--- a/playbooks/imports/play-AB-dnf-upgrade.yml
+++ b/playbooks/imports/play-AB-dnf-upgrade.yml
@@ -105,10 +105,27 @@
     # (because the parent `kernel` metapackage was versionlocked at the
     # previous-minor). Result: a "kernel" with no iwlwifi.ko / btusb.ko etc.
     # We detect and remove such half-installs so they don't clutter grub.
+    #
+    # SERVER SUPPORT (Plan 00161): this cleanup is a DESKTOP concern. A minimal
+    # Fedora Cloud/Server image legitimately ships kernel-core + kernel-modules-core
+    # and NO full kernel-modules — that is NOT a half-install. On a server the
+    # section would otherwise (a) hard-fail on `rpm -q kernel-modules` (rc 1, "not
+    # installed") under any_errors_fatal, and (b) if that were made tolerant, treat
+    # EVERY kernel as half-installed and `dnf remove` kernel-core +
+    # kernel-modules-core → an unbootable box. So it is skipped on the server profile;
+    # half_installed_kernels defaults to [] so the downstream length gates are safe.
+    - name: Default half-installed kernels to none (server profile skips the cleanup)
+      ansible.builtin.set_fact:
+        half_installed_kernels: []
+      tags:
+        - upgrade
+        - dnf
+
     - name: Enumerate installed kernel-core versions
       ansible.builtin.command: rpm -q kernel-core --queryformat '%{VERSION}-%{RELEASE} '
       register: kc_versions
       changed_when: false
+      when: provisioning_profile != 'server'
       tags:
         - upgrade
         - dnf
@@ -117,6 +134,7 @@
       ansible.builtin.command: rpm -q kernel-modules --queryformat '%{VERSION}-%{RELEASE} '
       register: km_versions
       changed_when: false
+      when: provisioning_profile != 'server'
       tags:
         - upgrade
         - dnf
@@ -124,6 +142,7 @@
     - name: Identify half-installed kernels (kernel-core without matching kernel-modules)
       ansible.builtin.set_fact:
         half_installed_kernels: "{{ kc_versions.stdout.split() | difference(km_versions.stdout.split()) | list }}"
+      when: provisioning_profile != 'server'
       tags:
         - upgrade
         - dnf

--- a/playbooks/imports/play-basic-configs.yml
+++ b/playbooks/imports/play-basic-configs.yml
@@ -312,6 +312,18 @@
       changed_when: true
       tags: grub
 
+    # SERVER SUPPORT (Plan 00161): fwupd (firmware updates) is a physical-hardware
+    # concern. A minimal Fedora Cloud/VM image does not ship fwupdmgr, so this task
+    # dies with rc 127 ("fwupdmgr: command not found") under any_errors_fatal. Gate it
+    # on fwupd actually being present — this skips VMs/minimal images while STILL
+    # running on a bare-metal server that has fwupd installed (better than a blanket
+    # server-profile skip, which would wrongly skip real firmware updates on metal).
+    - name: Check whether fwupd is available (VMs / minimal cloud images lack it)
+      ansible.builtin.shell: command -v fwupdmgr
+      register: fwupd_bin
+      changed_when: false
+      failed_when: false
+
     - name: Check and Apply Firmware Updates via fwupd
       ansible.builtin.shell: |
         set -e
@@ -341,3 +353,4 @@
         'Successfully installed firmware' in fwupd_result.stdout
         or 'has been updated' in fwupd_result.stdout
         or 'reboot is required' in fwupd_result.stdout | lower
+      when: fwupd_bin.rc == 0 # skip on VMs/minimal images without fwupd (Plan 00161)

--- a/playbooks/imports/play-lxc-install-config.yml
+++ b/playbooks/imports/play-lxc-install-config.yml
@@ -16,8 +16,29 @@
   become: true
   vars:
     root_dir: "{{ lookup('ansible.builtin.config', 'CONFIG_FILE') | dirname }}"
-    scope: general   # general | gnome | server — see CLAUDE/AnsibleStyle.md
+    # SERVER SUPPORT (Plan 00161): LXC here is desktop/dev-workstation tooling — it
+    # hard-requires Docker, the firewalld module (python3-firewall, absent on minimal
+    # Cloud), and a GitHub-SSH clone of "LXC Bash". None apply to a headless dev/prod
+    # server (podman is the container runtime there), so this play is desktop-only:
+    # scope 'gnome' makes the guard below end_play on the server profile, exactly like
+    # firefox/vscode/browsers (all 'gnome' = skip-on-server).
+    scope: gnome   # general | gnome | server — see CLAUDE/AnsibleStyle.md
   tasks:
+    - name: Scope guard — assert provisioning_profile is recognised
+      ansible.builtin.assert:
+        that:
+          - provisioning_profile in ['desktop', 'server']
+        fail_msg: |
+          provisioning_profile={{ provisioning_profile }} is not recognised.
+          Valid values: desktop, server.
+          Auto-detected from `systemctl get-default`
+          (see environment/localhost/group_vars/desktop.yml) or overridden
+          via -e provisioning_profile=desktop|server.
+
+    - name: Scope guard — end play if provisioning_profile does not match declared scope
+      ansible.builtin.meta: end_play
+      when: (scope == 'gnome' and provisioning_profile == 'server') or (scope == 'server' and provisioning_profile != 'server')
+
     # ── IaC Ordering Guard ─────────────────────────────────────────────────────
     - name: Check whether Docker is installed
       ansible.builtin.stat:

--- a/playbooks/imports/play-markless.yml
+++ b/playbooks/imports/play-markless.yml
@@ -32,6 +32,10 @@
           fi
           echo "upgrading from $installedVersion to $desiredVersion"
         fi
+        # SERVER SUPPORT (Plan 00161): a minimal Fedora Cloud/Server image has no
+        # ~/Downloads (a desktop XDG dir), so `cd` there aborts the run under
+        # any_errors_fatal. Create it first — a no-op on desktop, server-safe on VMs.
+        mkdir -p /home/{{ user_login }}/Downloads
         cd /home/{{ user_login }}/Downloads
         rm -rf markless*
         wget "{{ marklessUrl }}"

--- a/playbooks/imports/play-podman.yml
+++ b/playbooks/imports/play-podman.yml
@@ -12,6 +12,10 @@
       ansible.builtin.dnf:
         name:
           - podman
+          # A minimal Fedora Cloud/Server image ships no pip3, so the pip task below
+          # ("Install podman-compose") dies with "Unable to find any of pip3 to use".
+          # Install python3-pip here so the pip step works on server/headless too.
+          - python3-pip
         state: present
 
     - name: Install podman-compose (Docker Compose compatibility)

--- a/playbooks/imports/play-vpn.yml
+++ b/playbooks/imports/play-vpn.yml
@@ -28,8 +28,12 @@
         state: present
       when: provisioning_profile != 'server'
 
+    # The firewalld module needs the python3-firewall library, absent on a minimal
+    # Cloud/Server image; and a headless server is firewalled at the network edge
+    # (no local firewalld), so skip this desktop firewall rule on the server profile.
     - name: Allow OpenVPN Through Firewall
       ansible.posix.firewalld:
         service: openvpn
         permanent: true
         state: enabled
+      when: provisioning_profile != 'server'


### PR DESCRIPTION
## Server profile: fix desktop assumptions that abort headless/Cloud runs

Proving the `provisioning_profile=server` path on a minimal **Fedora 44 Cloud Base** VM
surfaced six plays that assume a desktop (hardware, firmware, GUI XDG dirs, a local
firewalld, or desktop-only tooling) and therefore hard-fail under `any_errors_fatal: true`
on a server/VM. The GNOME/GUI profile guard already works correctly (the ~35 desktop plays
skip); these are the remaining gaps.

Every change is a **pure addition** — the desktop path is unchanged, so there is zero
regression risk to existing desktop users. All proven end-to-end on a real Cloud VM (green
through podman + ccy + claude-code).

### 1. `play-AB-dnf-upgrade.yml` — kernel half-install cleanup (CRITICAL: would brick a VM)

The kernel half-install cleanup enumerates `rpm -q kernel-modules`. A minimal Cloud/Server
image legitimately ships `kernel-core` + `kernel-modules-core` and **no** full
`kernel-modules` — a valid minimal kernel, not a half-install. On a server this either
**(a)** hard-fails on `rpm -q kernel-modules` (rc 1) under `any_errors_fatal`, or **(b)** if
made tolerant, computes `half_installed_kernels` = **every kernel** and the removal `dnf`
task would remove `kernel-core` + `kernel-modules-core` for all of them → **an unbootable
box.**

**Fix:** default `half_installed_kernels: []` first, then gate the enumerate/identify tasks
on `provisioning_profile != 'server'`.

### 2. `play-basic-configs.yml` — fwupd firmware updates

"Check and Apply Firmware Updates via fwupd" runs `fwupdmgr`, absent on a minimal Cloud/VM
image → rc 127 aborts the run.

**Fix:** a `command -v fwupdmgr` presence-check gate — bare-metal servers with fwupd still
get firmware updates while VMs/minimal images skip.

### 3. `play-podman.yml` — podman-compose needs pip3

"Install podman-compose" uses the `pip` module, which fails with "Unable to find any of pip3
to use" — a minimal Cloud image has no `python3-pip`.

**Fix:** add `python3-pip` to the play's "Install Podman" dnf list.

### 4. `play-markless.yml` — assumes `~/Downloads` exists

The install shell does `cd ~/Downloads`, a desktop XDG dir absent on minimal Cloud → `cd`
aborts the run.

**Fix:** `mkdir -p ~/Downloads` before `cd` (no-op on desktop).

### 5. `play-vpn.yml` — OpenVPN firewalld rule needs python3-firewall

"Allow OpenVPN Through Firewall" uses the `firewalld` module, which needs `python3-firewall`
(absent on a minimal Cloud image). The play already keeps the VPN CLI packages and already
server-guards its GNOME applet task.

**Fix:** the same `when: provisioning_profile != 'server'` guard on the firewall-rule task.
A headless server is firewalled at the network edge and runs no local firewalld.

### 6. `play-lxc-install-config.yml` — desktop-only; server-skip it

This play is desktop/dev-workstation tooling: it hard-requires the container engine, uses
the `firewalld` module (`python3-firewall`, absent on minimal Cloud), and clones "LXC Bash"
over a GitHub SSH url. None of that applies to a headless server (podman is the runtime
there), and the firewalld import aborts the run.

**Fix:** classify it as desktop-only like `firefox`/`vscode`/`browsers`/`comms`/
`terminal-emulators` (all `scope: gnome`): set `scope: gnome` and add the standard two-task
scope guard so it cleanly `end_play`s on the server profile.

## Proven end-to-end

With these fixes, `ansible-playbook playbooks/playbook-main.yml -e provisioning_profile=server`
runs green on a Fedora 44 Cloud VM through dnf-upgrade → basic-configs → GitHub CLI → RPM
Fusion → podman → python → **claude-yolo (ccy)** image build → **claude-code** → markless →
VPN → repo-cleanup, with the GNOME/GUI/desktop plays (LXC included) skipping. The ccy
container image builds and `podman image inspect claude-yolo:latest` verifies; the
claude-code CLI installs and runs.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
